### PR TITLE
Qwen jax

### DIFF
--- a/cases/hourly_jax.csv
+++ b/cases/hourly_jax.csv
@@ -1,3 +1,6 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
-v6e-1,Qwen/Qwen2.5-1.5B-Instruct,64,512,1,2048,sonnet,1800,128
+v6e-1,Qwen/Qwen2.5-1.5B-Instruct,128,512,1,2048,sonnet,1800,128
+v6e-1,Qwen/Qwen2.5-7B-Instruct,128,512,1,2048,sonnet,1800,128
+v6e-8,Qwen/Qwen2.5-14B-Instruct,128,512,8,2048,sonnet,1800,128
+v6e-8,Qwen/Qwen2.5-32B,128,512,8,2048,sonnet,1800,128
 v6e-1,meta-llama/Llama-3.1-8B-Instruct,128,512,1,2048,sonnet,1800,128

--- a/cases/hourly_jax.csv
+++ b/cases/hourly_jax.csv
@@ -1,6 +1,6 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
-v6e-1,Qwen/Qwen2.5-1.5B-Instruct,128,512,1,2048,sonnet,1800,128
+v6e-1,Qwen/Qwen2.5-1.5B-Instruct,512,4096,1,2048,sonnet,1800,128
 v6e-1,Qwen/Qwen2.5-7B-Instruct,128,512,1,2048,sonnet,1800,128
 v6e-8,Qwen/Qwen2.5-14B-Instruct,128,512,8,2048,sonnet,1800,128
 v6e-8,Qwen/Qwen2.5-32B,128,512,8,2048,sonnet,1800,128
-v6e-1,meta-llama/Llama-3.1-8B-Instruct,128,512,1,2048,sonnet,1800,128
+v6e-1,meta-llama/Llama-3.1-8B-Instruct,256,1024,1,2048,sonnet,1800,128


### PR DESCRIPTION
As titled.

Currently I'm using the config from "best combination" sweep on Qwen2.5-1.5B-Instruct and Llama-3.1-8B-Instruct. For the other Qwen2.5 models, I used the config aligned with PyTorch-XLA.