### PR TITLE
Add ModelTag column

### DIFF
--- a/database/vllm_bm_20250729.ddl
+++ b/database/vllm_bm_20250729.ddl
@@ -1,0 +1,2 @@
+ALTER TABLE RunRecord ADD COLUMN ModelTag STRING(64) DEFAULT('PROD');
+CREATE INDEX IDX_RunRecord_ModelTag ON RunRecord (ModelTag);


### PR DESCRIPTION
ddl to add ModelTag as a column that can help distinguish between model implementations. 

Kept the default value as PROD, in the hope that default model is used in prod and any other experimentation will have a specific value.