### PR TITLE
[JAX] Add llama3 70B and update qwen

### DIFF
--- a/cases/hourly_jax.csv
+++ b/cases/hourly_jax.csv
@@ -1,7 +1,8 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts
 v6e-1,Qwen/Qwen2.5-1.5B-Instruct,512,4096,1,2048,sonnet,1800,128,,1000
-v6e-1,Qwen/Qwen2.5-7B-Instruct,128,512,1,2048,sonnet,1800,128,,1000
-v6e-8,Qwen/Qwen2.5-14B-Instruct,128,512,8,2048,sonnet,1800,128,,1000
-v6e-8,Qwen/Qwen2.5-32B,128,512,8,2048,sonnet,1800,128,,1000
+v6e-1,Qwen/Qwen2.5-7B-Instruct,256,2048,1,2048,sonnet,1800,128,,1000
+v6e-8,Qwen/Qwen2.5-14B-Instruct,256,2048,8,2048,sonnet,1800,128,,1000
+v6e-8,Qwen/Qwen2.5-32B,256,2048,8,2048,sonnet,1800,128,,1000
 v6e-1,meta-llama/Llama-3.1-8B-Instruct,256,1024,1,2048,sonnet,1800,128,,1000
-v6e-8,meta-llama/Llama-3.3-70B-Instruct,128,1024,1,2048,mmlu,1800,128,,1000
+v6e-8,meta-llama/Llama-3.1-70B-Instruct,128,1024,8,2048,mmlu,1800,128,,1000
+v6e-8,meta-llama/Llama-3.3-70B-Instruct,128,1024,8,2048,mmlu,1800,128,,1000


### PR DESCRIPTION
1. Add Llama 3.1 and 3.3 70B to JAX perf dashboard
2. Update JAX Qwen serving params to the same as torchax