### PR TITLE
CSVs not required to end with newline.

### DIFF
--- a/scripts/scheduler/schedule_run.sh
+++ b/scripts/scheduler/schedule_run.sh
@@ -27,7 +27,7 @@ VERY_LARGE_EXPECTED_ETEL=3600000
 # export GCP_DATABASE_ID="your-database"
 
 # === Read CSV and skip header ===
-tail -n +2 "$CSV_FILE" | while read -r line; do
+tail -n +2 "$CSV_FILE" | while read -r line || [ -n "${line}" ]; do
 
   line=$(echo "$line" | tr -d '\r')
     # Safely split CSV line into variables


### PR DESCRIPTION
Spent way too long trying to figure out why my accuracy runs were not being correctly handled and it turns out to be a newline issue. 

This change makes .csv files work with `schedule_run.sh` regardless of the newline existing at the end or not. 