### PR TITLE
Adds MLPerf dataset

### DIFF
--- a/cases/accuracy_jax.csv
+++ b/cases/accuracy_jax.csv
@@ -1,3 +1,3 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts
-v6e-1,meta-llama/Llama-3.1-8B-Instruct,256,1024,1,2048,mmlu,1800,128,,1000
 v6e-8,meta-llama/Llama-3.3-70B-Instruct,128,1024,8,2048,mmlu,1800,128,,1000
+v6e-8,meta-llama/Llama-3.3-70B-Instruct,128,1024,8,2048,mlperf,1024,1024,,1000

--- a/scripts/agent/docker_run_bm.sh
+++ b/scripts/agent/docker_run_bm.sh
@@ -87,8 +87,10 @@ docker run \
  -v /dev/shm:/dev/shm \
  $image_tag tail -f /dev/null
 
-# =============== temp solution ===============
-if [ "$DATASET" = "custom-token" ] || [ "$DATASET" = "mmlu" ] || [ "$DATASET" = "bench-custom-token" ]; then
+# =============== temp solution start ===============
+
+DATASETS=("custom-token" "mmlu" "mlperf" "bench-custom-token")
+if [[ " ${DATASETS[*]} " == * " $DATASET " * ]]; then
   echo "Temp solution: Syncing dataset for $DATASET"
 
   mkdir -p ./artifacts/dataset/
@@ -99,6 +101,9 @@ if [ "$DATASET" = "custom-token" ] || [ "$DATASET" = "mmlu" ] || [ "$DATASET" = 
   elif [ "$DATASET" = "mmlu" ]; then
     # Download mmlu directory recursively
     gsutil -m cp -r gs://$GCS_BUCKET/dataset/mmlu/* ./artifacts/dataset/
+  elif [ "$DATASET" = "mlperf" ]; then
+    # Download single pkl file for MLPerf
+    gsutil -m cp -r gs://$GCS_BUCKET/dataset/mlperf/processed-data.pkl ./artifacts/dataset/
   elif [ "$DATASET" = "bench-custom-token" ]; then
     # Download flat files for custom-token
     gsutil -m cp -r gs://$GCS_BUCKET/bench-dataset/* ./artifacts/dataset/
@@ -114,7 +119,7 @@ if [ "$DATASET" = "custom-token" ] || [ "$DATASET" = "mmlu" ] || [ "$DATASET" = 
   docker cp scripts/agent/benchmark_dataset.py "$CONTAINER_NAME:/workspace/vllm/benchmarks/benchmark_dataset.py"
 fi
 
-# ===============  temp solution ===============
+# =============== temp solution end ===============
 
 if [ "$DATASET" = "sharegpt" ]; then  
   echo "Copying dataset to container..."

--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -35,6 +35,8 @@ mkdir -p "$PROFILE_FOLDER"
 # Ingore the error because in case of using uv, the packages are installed outside this script.
 pip install pandas || true
 pip install datasets || true
+pip install evaluate==0.4.5 || true
+pip install rouge-score==0.1.2 || true
 
 if [ "$DATASET" = "sonnet" ]; then
   echo "Create sonnet_4x.txt"
@@ -142,6 +144,19 @@ run_benchmark(){
       --dataset-path /workspace/dataset \
       --mmlu-num-shots 5 \
       --mmlu-method HELM \
+      --num-prompts ${NUM_PROMPTS} \
+      --percentile-metrics ttft,tpot,itl,e2el \
+      $PROFILE_FLAG \
+      --ignore-eos > "$BM_LOG" 2>&1
+  elif [ "$DATASET" = "mlperf" ]; then
+    python benchmarks/benchmark_serving.py \
+      --backend vllm \
+      --model $MODEL \
+      --request-rate $request_rate \
+      --dataset-name mlperf \
+      --dataset-path /workspace/dataset/processed-data.pkl \
+      --mlperf-input-len $INPUT_LEN \
+      --max-model-len $MAX_MODEL_LEN \
       --num-prompts ${NUM_PROMPTS} \
       --percentile-metrics ttft,tpot,itl,e2el \
       $PROFILE_FLAG \

--- a/scripts/scheduler/hourly_run.sh
+++ b/scripts/scheduler/hourly_run.sh
@@ -76,9 +76,6 @@ echo "./scripts/scheduler/create_job.sh ./cases/hourly_jax.csv \"\" $TAG HOURLY_
 # Run JAX with new model design
 ./scripts/scheduler/create_job.sh ./cases/hourly_jax_new.csv "" $TAG HOURLY_JAX TPU_COMMONS "TPU_BACKEND_TYPE=jax;NEW_MODEL_DESIGN=True"
 
-# Run JAX with mmlu dataset
-./scripts/scheduler/create_job.sh ./cases/hourly_jax_mmlu.csv "" $TAG HOURLY_JAX_MMLU TPU_COMMONS "TPU_BACKEND_TYPE=jax"
-
 # Run Torchax + jax backend
 echo "./scripts/scheduler/create_job.sh ./cases/hourly_torchax_jax.csv \"\" $TAG HOURLY_AX_JAX TPU_COMMONS \"TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm\""
 ./scripts/scheduler/create_job.sh ./cases/hourly_torchax_jax.csv "" $TAG HOURLY_AX_JAX TPU_COMMONS "TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm"
@@ -115,6 +112,10 @@ if [[ "$HOUR_NOW" == "00" || "$HOUR_NOW" == "12" ]]; then
   # TODO - Move this to nightly once we have more stable runs
   echo "./scripts/scheduler/create_job.sh ./cases/nightly_jax.csv \"\" $TAG BENCH_COMP_TPU TPU_COMMONS \"TPU_BACKEND_TYPE=jax;NEW_MODEL_DESIGN=True\""
   ./scripts/scheduler/create_job.sh ./cases/nightly_jax.csv "" $TAG BENCH_COMP_TPU TPU_COMMONS "TPU_BACKEND_TYPE=jax;NEW_MODEL_DESIGN=True"
+
+  # JAX accuracy
+  echo "./scripts/scheduler/create_job.sh ./cases/accuracy_jax.csv \"\" $TAG AUTOTUNE_AX_JAX TPU_COMMONS \"TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm\""
+  ./scripts/scheduler/create_job.sh ./cases/accuracy.csv "" $TAG AUTOTUNE_AX_JAX TPU_COMMONS "TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm"
 
   # Adhoc
   # echo "./scripts/scheduler/create_job.sh ./cases/autotune_adhoc.csv \"\" $TAG AUTOTUNE "


### PR DESCRIPTION
Some key changes

1. Adds support for MLPerf/OpenOrca dataset via `MLPerfDataset` class
2. Adds support for ROUGE metrics using the `evaluate` and `rouge-score` libraries.
3. Moves accuracy-based runs to just large models (llama3 70b currently instead of llama3 8b). 
4. Accuracy runs are now made twice a day instead of every hour. 
5. Makes matching for the mmlu dataset slightly more robust. 