### PR TITLE
Accuracy fixes for MMLU

### DIFF
--- a/scripts/agent/benchmark_dataset.py
+++ b/scripts/agent/benchmark_dataset.py
@@ -296,8 +296,8 @@ class MMLUDataset(BenchmarkDataset):
         assert dataset_path != ""
         dataset = []
         prompts_per_subject = dict()
-        for root, _, files in os.walk(dataset_path):
-            for csv_file in files:
+        for root, _, files in sorted(os.walk(dataset_path)):
+            for csv_file in sorted(files):
                 if csv_file.endswith(".csv"):
                     subject = " ".join(csv_file.split("_")[:-1])
                     if subject not in prompts_per_subject:
@@ -311,6 +311,8 @@ class MMLUDataset(BenchmarkDataset):
             raise FileNotFoundError(f"No CSV files found in {dataset_path}")
 
         combined_dataset = pd.concat(dataset, ignore_index=True)
+        combined_dataset = combined_dataset.sample(
+            frac=1, random_state=self.random_seed).reset_index(drop=True)
         header_dict = {
             0: "question",
             1: "A",
@@ -368,6 +370,8 @@ class MMLUDataset(BenchmarkDataset):
             prompt = prompts_per_subject[row["subject"]] + question_prompt
             mmlu_data.append((prompt, output))
 
+        random.seed(self.random_seed)
+        random.shuffle(mmlu_data)
         self.data = mmlu_data
 
     def sample(

--- a/scripts/agent/benchmark_serving.py
+++ b/scripts/agent/benchmark_serving.py
@@ -633,6 +633,9 @@ async def benchmark(
         dataset_name=dataset_name,
     )
 
+    if metrics.accuracy_metrics:
+        print(f"AccuracyMetrics: {json.dumps(metrics.accuracy_metrics)}")
+
     print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
     print("{:<40} {:<10}".format("Successful requests:", metrics.completed))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
@@ -883,6 +886,7 @@ def main(args: argparse.Namespace):
         input_requests = dataset.sample(
             tokenizer=tokenizer,
             num_requests=args.num_prompts,
+            max_model_len=args.max_model_len,
         )
 
     elif args.dataset_name == "mlperf":
@@ -1377,7 +1381,7 @@ def create_argument_parser():
     mmlu_group.add_argument(
         "--mmlu-num-shots",
         type=int,
-        default=5,
+        default=0,
         help="Number of shots for MMLU few-shot examples.",
     )
     mmlu_group.add_argument(

--- a/scripts/agent/docker_run_bm.sh
+++ b/scripts/agent/docker_run_bm.sh
@@ -157,6 +157,7 @@ output_token_throughput=$(grep "Output token throughput (tok/s):" "$BM_LOG" | se
 total_token_throughput=$(grep "Total Token throughput (tok/s):" "$BM_LOG" | sed 's/[^0-9.]//g')
 # Extract the JSON string for accuracy metrics. The sed command removes the 'AccuracyMetrics: ' prefix.
 AccuracyMetricsJSON=$(grep "AccuracyMetrics:" "$BM_LOG" | sed 's/AccuracyMetrics: //')
+echo "AccuracyMetricsJSON: $AccuracyMetricsJSON"
 
 #
 # compare the throughput with EXPECTED_THROUGHPUT 

--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -142,7 +142,7 @@ run_benchmark(){
       --request-rate $request_rate \
       --dataset-name mmlu \
       --dataset-path /workspace/dataset \
-      --mmlu-num-shots 5 \
+      --mmlu-num-shots 0 \
       --mmlu-method HELM \
       --num-prompts ${NUM_PROMPTS} \
       --percentile-metrics ttft,tpot,itl,e2el \


### PR DESCRIPTION
We saw inconsistent accuracy results in prod that did not exist in local runs. This stems largely from non-determinism in how `os.walk` can process files which matters in MMLU's case because it's made up of various .csv files. 

1. Files are now sorted first and shuffled using a consistent random seed. 
2. MMLU now uses zero-shot for accuracy
3. Fix for missing accuracy outputs. 