### PR TITLE
[Qwen-vl] Fix backend and endpoint type

### DIFF
--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -217,12 +217,13 @@ run_benchmark(){
   elif [ "$DATASET" = "hf" ]; then
     dataset_path="lmarena-ai/VisionArena-Chat" 
     python benchmarks/benchmark_serving.py \
-      --backend vllm \
+      --backend openai-chat \
       --model $MODEL \
       --request-rate $request_rate \
       --dataset-name hf \
       --dataset-path $dataset_path \
       --num-prompts "$NUM_PROMPTS" \
+      --endpoint /v1/chat/completions \
       --percentile-metrics ttft,tpot,itl,e2el \
       $PROFILE_FLAG \
       --ignore-eos > "$BM_LOG" 2>&1


### PR DESCRIPTION
As titled. The backend is required for multi-modal data.

Have tested on: https://buildkite.com/tpu-commons/tpu-commons-ci/builds/2049#0198c93e-097c-4dd2-929c-cfb5cdb68140