### PR TITLE
Fixes parsing of acc and perf benchmarks.

### DIFF
--- a/scripts/agent/docker_run_bm.sh
+++ b/scripts/agent/docker_run_bm.sh
@@ -174,9 +174,14 @@ else
   total_token_throughput=$(grep "Total Token throughput (tok/s):" "$BM_LOG" | sed 's/[^0-9.]//g')
 
   if [[ -z "$throughput" || ! "$throughput" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-    echo "Failed to get the throughput"
-    echo "AccuracyMetrics=$AccuracyMetricsJSON" > "artifacts/$RECORD_ID.result"
-    exit 0
+    if [[ -n "$AccuracyMetricsJSON" ]]; then
+      echo "Failed to get the throughput, but found accuracy metrics."
+      echo "AccuracyMetrics=$AccuracyMetricsJSON" > "artifacts/$RECORD_ID.result"
+      exit 0
+    else
+      echo "Failed to get the throughput and no accuracy metrics found."
+      exit 1
+    fi
   fi
 
   if (( $(echo "$throughput < $EXPECTED_THROUGHPUT" | bc -l) )); then


### PR DESCRIPTION
Fixes b/445996782 where failed benchmark runs were incorrectly reported as COMPLETED.

The docker_run_bm.sh script has been updated to only create a .result file if valid throughput and/or accuracy metrics are found in the logs. If no metrics exist, the script now exits with a failure, ensuring that failed runs are correctly reported.