### PR TITLE
Add basic disaggregated serving benchmark for GKE

### DIFF
--- a/kubernetes/manifests/storageclass.yaml
+++ b/kubernetes/manifests/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: balanced-storage
+provisioner: pd.csi.storage.gke.io # The name of the provisioner (CSI driver)
+parameters:
+  type: pd-balanced # Specifies a balanced disk type on GCP
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer 

--- a/kubernetes/manifests/v7x/proxy1p1d.yaml
+++ b/kubernetes/manifests/v7x/proxy1p1d.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-disagg-proxy
+  labels:
+    app: vllm-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-proxy
+  template:
+    metadata:
+      labels:
+        app: vllm-proxy
+    spec:
+      containers:
+      - name: proxy-container
+        image: vllm/vllm-tpu:nightly
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            # Start the proxy server in the background
+            python3 examples/disagg/toy_proxy_server.py \
+              --host 0.0.0.0 \
+              --port 10000 \
+              --prefiller-host vllm-service-prefill \
+              --prefiller-port 8000 \
+              --decoder-host vllm-service-decode \
+              --decoder-port 8000 &
+            # Keep the container alive for benchmarking
+            echo "Proxy started. Ready for benchmark."
+            tail -f /dev/null
+        ports:
+        - containerPort: 10000
+        resources:
+          requests:
+            cpu: "8"
+            memory: "16Gi"
+            ephemeral-storage: "20Gi"
+          limits:
+            cpu: "16"
+            memory: "32Gi"

--- a/kubernetes/manifests/v7x/single_decode.yaml
+++ b/kubernetes/manifests/v7x/single_decode.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-vllm-d
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: balanced-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-decode
+  template:
+    metadata:
+      labels:
+        app: vllm-decode
+    spec:
+      serviceAccountName: default
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 2x2x1
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+      initContainers:
+        - name: tpu-node-setup
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # WARNING: This changes the HOST memory settings, not just the container.
+              # Required to prevent vLLM crashes due to memory mapping limits.
+              sysctl -w vm.max_map_count=8388608
+
+              # Check if the VFIO IOMMU module parameter exists, and if so, increase the
+              # limit on DMA mappings. This allows the TPU driver to pin and map a
+              # larger number of memory pages for direct hardware access.
+              if [ -f /sys/module/vfio_iommu_type1/parameters/dma_entry_limit ]; then
+                echo 2000000 > /sys/module/vfio_iommu_type1/parameters/dma_entry_limit
+                echo "Successfully increased dma_entry_limit to 2000000"
+              else
+                echo "Warning: vfio_iommu_type1 module parameter not found. Ensure the module is loaded."
+              fi
+          securityContext:
+            privileged: true
+      containers:
+      - name: vllm-tpu
+        image: vllm/vllm-tpu:nightly
+        imagePullPolicy: Always
+        command: [ "/bin/bash", "-c", "--" ]
+        args: ["vllm serve --seed=42 --model=BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size=8 --kv-cache-dtype=fp8 --gpu-memory-utilization=0.90 --async-scheduling --enable-expert-parallel --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_consumer\"}'"]
+        env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token-secret
+              key: token
+        - name: HF_HOME
+          value: /usr/vllm
+        - name: VLLM_LOGGING_LEVEL
+          value: "DEBUG"
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_BACKEND_TYPE
+          value: jax
+        - name: PJRT_DEVICE
+          value: TPU
+        - name: USE_MOE_EP_KERNEL
+          value: "0"
+        - name: MODEL_IMPL_TYPE
+          value: "vllm"
+        - name: USE_BATCHED_RPA_KERNEL
+          value: "0"
+        ports:
+        - containerPort: 8000
+        resources:
+          limits:
+            google.com/tpu: "4"
+            memory: "850Gi"
+            cpu: "220"
+            ephemeral-storage: "40Gi"
+          requests:
+            google.com/tpu: "4"
+            memory: "850Gi"
+            cpu: "220"
+            ephemeral-storage: "40Gi"
+        volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: pvc-vllm-vol
+          mountPath: "/usr/vllm"
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: pvc-vllm-vol
+        persistentVolumeClaim:
+          claimName: pvc-vllm-d
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-service-decode
+  labels:
+    app: vllm-decode
+spec:
+  type: ClusterIP
+  selector:
+    app: vllm-decode
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/kubernetes/manifests/v7x/single_prefill.yaml
+++ b/kubernetes/manifests/v7x/single_prefill.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-vllm-p
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: balanced-storage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-prefill
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-prefill
+  template:
+    metadata:
+      labels:
+        app: vllm-prefill
+    spec:
+      serviceAccountName: default
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 2x2x1
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+      initContainers:
+        - name: tpu-node-setup
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # WARNING: This changes the HOST memory settings, not just the container.
+              # Required to prevent vLLM crashes due to memory mapping limits.
+              sysctl -w vm.max_map_count=8388608
+
+              # Check if the VFIO IOMMU module parameter exists, and if so, increase the
+              # limit on DMA mappings. This allows the TPU driver to pin and map a
+              # larger number of memory pages for direct hardware access.
+              if [ -f /sys/module/vfio_iommu_type1/parameters/dma_entry_limit ]; then
+                echo 2000000 > /sys/module/vfio_iommu_type1/parameters/dma_entry_limit
+                echo "Successfully increased dma_entry_limit to 2000000"
+              else
+                echo "Warning: vfio_iommu_type1 module parameter not found. Ensure the module is loaded."
+              fi
+          securityContext:
+            privileged: true
+      containers:
+      - name: vllm-tpu
+        image: vllm/vllm-tpu:nightly
+        imagePullPolicy: Always
+        command: [ "/bin/bash", "-c", "--" ]
+        args: ["vllm serve --seed=42 --model=BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic --max-model-len=10240 --max-num-batched-tokens=8192 --max-num-seqs=512 --no-enable-prefix-caching --tensor-parallel-size=8 --kv-cache-dtype=fp8 --gpu-memory-utilization=0.70 --async-scheduling --enable-expert-parallel --kv-transfer-config '{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_producer\"}'"]
+        env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token-secret
+              key: token
+        - name: HF_HOME
+          value: /usr/vllm
+        - name: VLLM_LOGGING_LEVEL
+          value: "DEBUG"
+        - name: JAX_PLATFORMS
+          value: "tpu,cpu"
+        - name: TPU_BACKEND_TYPE
+          value: jax
+        - name: PJRT_DEVICE
+          value: TPU
+        - name: USE_MOE_EP_KERNEL
+          value: "0"
+        - name: MODEL_IMPL_TYPE
+          value: "vllm"
+        - name: USE_BATCHED_RPA_KERNEL
+          value: "0"
+        ports:
+        - containerPort: 8000
+        resources:
+          limits:
+            google.com/tpu: "4"
+            memory: "850Gi"
+            cpu: "220"
+            ephemeral-storage: "40Gi"
+          requests:
+            google.com/tpu: "4"
+            memory: "850Gi"
+            cpu: "220"
+            ephemeral-storage: "40Gi"
+        volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: pvc-vllm-vol
+          mountPath: "/usr/vllm"
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+            - IPC_LOCK
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: pvc-vllm-vol
+        persistentVolumeClaim:
+          claimName: pvc-vllm-p
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-service-prefill
+  labels:
+    app: vllm-prefill
+spec:
+  type: ClusterIP
+  selector:
+    app: vllm-prefill
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000

--- a/scripts/scheduler/daily_run_gke_disagg.sh
+++ b/scripts/scheduler/daily_run_gke_disagg.sh
@@ -14,7 +14,7 @@ init_env() {
 
     # Ensure HF_TOKEN is set
     echo "kubectl create secret generic hf-token-secret --from-literal=token=$HF_TOKEN"
-    kubectl create secret generic hf-token-secret --from-literal=token=$HF_TOKEN
+    kubectl create secret generic hf-token-secret --from-literal=token=$HF_TOKEN --dry-run=client -o yaml | kubectl apply -f -
 
     # Create storage class
     echo "kubectl apply -f ./kubernetes/manifests/storageclass.yaml"

--- a/scripts/scheduler/daily_run_gke_disagg.sh
+++ b/scripts/scheduler/daily_run_gke_disagg.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+MODEL="BCCard/Qwen3-Coder-480B-A35B-Instruct-FP8-Dynamic"
+PREFILL_LABEL="app=vllm-prefill"
+DECODE_LABEL="app=vllm-decode"
+PROXY_LABEL="app=vllm-proxy"
+INTERVAL=5
+TIMEOUT_SECONDS=7200
+
+init_env() {
+    # Get credentials to GKE cluster
+    echo "gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE --project $PROJECT_NAME"
+    gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE --project $PROJECT_NAME
+
+    # Ensure HF_TOKEN is set
+    echo "kubectl create secret generic hf-token-secret --from-literal=token=$HF_TOKEN"
+    kubectl create secret generic hf-token-secret --from-literal=token=$HF_TOKEN
+
+    # Create storage class
+    echo "kubectl apply -f ./kubernetes/manifests/storageclass.yaml"
+    kubectl apply -f ./kubernetes/manifests/storageclass.yaml
+}
+
+deploy_1p1d() {
+    echo "kubectl apply -f ./kubernetes/manifests/v7x/single_prefill.yaml"
+    kubectl apply -f ./kubernetes/manifests/v7x/single_prefill.yaml
+
+    echo "kubectl apply -f ./kubernetes/manifests/v7x/single_decode.yaml"
+    kubectl apply -f ./kubernetes/manifests/v7x/single_decode.yaml
+
+    echo "kubectl apply -f ./kubernetes/manifests/v7x/proxy1p1d.yaml"
+    kubectl apply -f ./kubernetes/manifests/v7x/proxy1p1d.yaml
+}
+
+cleanup_1p1d() {
+    echo "kubectl delete -f ./kubernetes/manifests/v7x/single_prefill.yaml"
+    kubectl delete -f ./kubernetes/manifests/v7x/single_prefill.yaml
+
+    echo "kubectl delete -f ./kubernetes/manifests/v7x/single_decode.yaml"
+    kubectl delete -f ./kubernetes/manifests/v7x/single_decode.yaml
+
+    echo "kubectl delete -f ./kubernetes/manifests/v7x/proxy1p1d.yaml"
+    kubectl delete -f ./kubernetes/manifests/v7x/proxy1p1d.yaml
+}
+
+wait_for_vllm() {
+    local label=$1
+    local name=$2
+
+    echo "Waiting for $name ($label) to be ready..."
+
+    while true; do
+        # Check if we have exceeded the 2-hour timeout
+        if [ "$SECONDS" -ge "$TIMEOUT_SECONDS" ]; then
+            echo "ERROR: Pods failed to start after the maximum timeout."
+            exit 1
+        fi
+
+        # Get the pod name dynamically
+        POD_NAME=$(kubectl get pods -l "$label" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+
+        if [ -n "$POD_NAME" ]; then
+            # Check logs for the startup string
+            if kubectl logs "$POD_NAME" --tail 50 2>/dev/null | grep -q "Application startup complete"; then
+                echo "$name is ready! (Elapsed: $((SECONDS / 60))m)"
+                break
+            fi
+        fi
+
+        sleep "$INTERVAL"
+    done
+}
+
+run_disagg_benchmark() {
+    local proxy=$1
+    local model=$2
+    local input_len=$3
+    local output_len=$4
+    local num_prompts=$5
+    local filename="${input_len}_${output_len}.json"
+
+    for RATE in 0.5 1.0 2.0 3.0 4.0 5.0
+    do
+        echo "-------------------------------------------------------"
+        echo "Starting Benchmark: Rate=$RATE, Input=$input_len, Output=$output_len"
+        echo "-------------------------------------------------------"
+
+        kubectl exec $proxy -- vllm bench serve \
+            --model=$model \
+            --dataset-name=random \
+            --random-input-len=$input_len \
+            --random-output-len=$output_len \
+            --num-prompts=$num_prompts \
+            --ignore-eos \
+            --host=localhost \
+            --port=10000 \
+            --request-rate=$RATE \
+            --metric-percentiles 90,99 \
+            --append-result \
+            --result-file=$filename
+
+        sleep 2
+    done
+
+    kubectl cp "${proxy}:${filename}" "./${filename}.json"
+}
+
+
+if [ -z "${HF_TOKEN:-}" ]; then
+  echo "Error: HF_TOKEN is not set."
+  exit 1
+fi
+
+if [ -z "${PROJECT_NAME:-}" ]; then
+  echo "Error: PROJECT_NAME is not set."
+  exit 1
+fi
+
+if [ -z "${CLUSTER_NAME:-}" ]; then
+  echo "Error: CLUSTER_NAME is not set."
+  exit 1
+fi
+
+if [ -z "${ZONE:-}" ]; then
+  echo "Error: ZONE is not set."
+  exit 1
+fi
+
+# Initialize GKE environment
+init_env
+
+# Deploy 1P1D disaggregated serving
+deploy_1p1d
+
+START_TIME=$SECONDS
+
+# Wait for Prefill
+wait_for_vllm "$PREFILL_LABEL" "prefill"
+
+# Wait for Decode
+wait_for_vllm "$DECODE_LABEL" "decode"
+
+echo "------------------------------------------------"
+echo "Ready to benchmark. Total wait time: $(( (SECONDS - START_TIME) / 60 )) minutes."
+echo "------------------------------------------------"
+
+# Find the pod name for the proxy server
+PROXY_POD=$(kubectl get pods -l "$PROXY_LABEL" -o jsonpath="{.items[0].metadata.name}")
+
+# Run input=1024, output=8192
+run_disagg_benchmark $PROXY_POD $MODEL 1024 8192 256
+
+# Run input=8192, output=1024
+run_disagg_benchmark $PROXY_POD $MODEL 8192 1024 256
+
+# Benchmark results should be saved in local files 1024_8192.json and
+# 8192_1024.json.
+# Need to extract metrics like:
+# - Throughput
+# - TTFT (mean, median, P90)
+# - TPOT (mean, median, P90)
+
+# Cleanup
+cleanup_1p1d

--- a/scripts/scheduler/daily_run_gke_disagg.sh
+++ b/scripts/scheduler/daily_run_gke_disagg.sh
@@ -102,7 +102,7 @@ run_disagg_benchmark() {
         sleep 2
     done
 
-    kubectl cp "${proxy}:${filename}" "./${filename}.json"
+    kubectl cp "${proxy}:${filename}" "./${filename}"
 }
 
 


### PR DESCRIPTION
This PR adds a basic disaggregated serving benchmark using DCN KV transfer on GKE.

Usage:

```
# Set environment variables for host project and HF token, for example:
export HF_TOKEN=<token>
export PROJECT_NAME=cloud-tpu-inference-test
export CLUSTER_NAME=ricliu-v7x-2
export ZONE=us-central1-c
./scripts/scheduler/daily_run_gke_disagg.sh 
```

TODO:
* Enable benchmark on CI?CD project
* Enable scheduler to run test daily
* Parse and store results to database
* Add Looker dashboard for benchmark results