### PR TITLE
Fix torchtpu-vllm repo URL and bump torch-tpu version

### DIFF
--- a/docker/DockerfileTT
+++ b/docker/DockerfileTT
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 # The vllm's tag: v0.17.1
 ARG VLLM_COMMIT_HASH="95c0f928c"
 
-ARG TORCH_VERSION="0.1.1.dev20260327092459"
+ARG TORCH_VERSION="0.1.1.dev20260409225702"
 
 #
 # Build and install vLLM

--- a/scripts/scheduler/build_tt_image.sh
+++ b/scripts/scheduler/build_tt_image.sh
@@ -12,7 +12,7 @@ export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)
 # 2. Fetch the version of torch_tpu
 # This runs a tiny container to check the version from the registry
 
-TORCH_VERSION="0.1.1.dev20260327092459"
+TORCH_VERSION="0.1.1.dev20260409225702"
 # echo "Determining torch_tpu version..."
 # TORCH_VERSION=$(docker run --rm \
 #     -e GOOGLE_ACCESS_TOKEN=$GOOGLE_ACCESS_TOKEN \

--- a/scripts/scheduler/create_tt_job.sh
+++ b/scripts/scheduler/create_tt_job.sh
@@ -117,7 +117,7 @@ clone_and_get_hash() {
 }
 
 # Clone and get hash
-TT_VLLM_HASH=$(clone_and_get_hash "https://github.com/google-ml-infra/torchtpu-vllm.git" "artifacts/torchtpu-vllm" "$TT_VLLM_HASH")
+TT_VLLM_HASH=$(clone_and_get_hash "https://github.com/google-pytorch/torchtpu-vllm.git" "artifacts/torchtpu-vllm" "$TT_VLLM_HASH")
 echo "resolved TT_VLLM_HASH: $TT_VLLM_HASH"
 
 echo "./scripts/scheduler/build_tt_vllm_image.sh $TT_VLLM_HASH"


### PR DESCRIPTION
## Summary
- Update `torchtpu-vllm` clone URL from `google-ml-infra` to `google-pytorch` org
- Bump `torch-tpu` to `0.1.1.dev20260409225702` in `DockerfileTT` and `build_tt_image.sh`, aligning with the version pinned in `torchtpu-vllm`

## Test plan
1. base image publish.
2. will publish and see the result in next hour.