### PR TITLE
add Qwen3-Coder models for TorchTPU benchmark

### DIFF
--- a/cases/hourly_tt_v7.csv
+++ b/cases/hourly_tt_v7.csv
@@ -1,4 +1,4 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
-tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,1,10275,sonnet,1024,1024
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,1,10275,sonnet,1024,8096
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,1,10275,sonnet,8096,1024

--- a/cases/hourly_tt_v7_ep.csv
+++ b/cases/hourly_tt_v7_ep.csv
@@ -1,0 +1,7 @@
+Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,8,10275,sonnet,1024,1024
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,8,10275,sonnet,1024,8096
+tpu7x-8,Qwen/Qwen3-Coder-30B-A3B-Instruct,8,10275,8,10275,sonnet,8096,1024
+tpu7x-8,Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,8,10275,8,10275,sonnet,1024,1024
+tpu7x-8,Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,8,10275,8,10275,sonnet,1024,8096
+tpu7x-8,Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,8,10275,8,10275,sonnet,8096,1024

--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -101,6 +101,11 @@ if [[ "${FORCE_EAGER:-,,}" == "true" ]]; then
   EXTRA_ARGS+=" --enforce-eager"
 fi
 
+# If ENABLE_EXPERT_PARALLEL is set to true (case-insensitive), append flag
+if [[ "${ENABLE_EXPERT_PARALLEL:-,,}" == "true" ]]; then
+  EXTRA_ARGS+=" --enable-expert-parallel"
+fi
+
 VLLM_USE_V1=1 VLLM_TORCH_PROFILER_DIR="$PROFILE_FOLDER" vllm serve $MODEL \
   --seed 42 \
   --max-num-seqs $MAX_NUM_SEQS \

--- a/scripts/scheduler/hourly_run.sh
+++ b/scripts/scheduler/hourly_run.sh
@@ -142,6 +142,10 @@ bash ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt.csv "" $TAG HOURLY_T
 echo ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7.csv \"\" $TAG HOURLY_TT '\"MODEL_IMPL_TYPE=vllm;TEMPERATURE=0\"' tt
 bash ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7.csv "" $TAG HOURLY_TT "MODEL_IMPL_TYPE=vllm;TEMPERATURE=0" "tt"
 
+# Run TTV v7 with EP
+echo "./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7_ep.csv"
+bash ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7_ep.csv "" $TAG HOURLY_TT "MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true" "tt"
+
 # torchax v7
 echo "./scripts/scheduler/create_job.sh ./cases/hourly_torchax_jax_v7.csv \"\" $TAG HOURLY_AX_JAX TPU_INFERENCE \"TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm\" tt"
 ./scripts/scheduler/create_job.sh ./cases/hourly_torchax_jax_v7.csv "" $TAG HOURLY_AX_JAX TPU_INFERENCE "TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm" tt


### PR DESCRIPTION
The test cases are listed in b/479885992#comment15.

### Test

Successfully inserted the records to Spanner table:

```
yiweiw_google_com@t1v-n-f20d5aa2-w-0:~/bm-infra$ gcloud spanner databases execute-sql vllm-bm-runs \
   --instance=vllm-bm-inst \
   --project=cloud-tpu-inference-test \
   --sql="SELECT Model, TensorParallelSize, ExtraEnvs, Status 
          FROM RunRecord 
          WHERE JobReference = 'YIWEI_TEST_1776148137' 
          ORDER BY CreatedTime DESC;"
Model                                    TensorParallelSize  ExtraEnvs                                                       Status
Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8  8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  CREATED
Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8  8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  CREATED
Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8  8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  CREATED
Qwen/Qwen3-Coder-30B-A3B-Instruct        8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  CREATED
Qwen/Qwen3-Coder-30B-A3B-Instruct        8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  CREATED
Qwen/Qwen3-Coder-30B-A3B-Instruct        8                   MODEL_IMPL_TYPE=vllm;TEMPERATURE=0;ENABLE_EXPERT_PARALLEL=true  RUNNING
```
And

```
yiweiw_google_com@t1v-n-f20d5aa2-w-0:~/bm-infra$ ./scripts/manager/get_status.sh YIWEI_TEST_1776148137 --verbose
Querying records for JobReference LIKE 'YIWEI_TEST_1776148137%...'
Found 6 matching records:

JobReference              Model                          Status          Device          Throughput   VLLM Log
------------------------- ------------------------------ --------------- --------------- ------------ ------------------------------------------------------------------------------------------------
YIWEI_TEST_1776148137     Qwen3-Coder-30B-A3B-Instruct   CREATED         tpu7x-8         N/A          go/bm-log/009088eb-4699-4c0a-9363-939e5a10d817/static_vllm_log.txt
YIWEI_TEST_1776148137     Qwen3-Coder-480B-A35B-Instruct-FP8 CREATED         tpu7x-8         N/A          go/bm-log/0f813a4e-e880-4bbd-8652-afd8820854fc/static_vllm_log.txt
YIWEI_TEST_1776148137     Qwen3-Coder-30B-A3B-Instruct   CREATED         tpu7x-8         N/A          go/bm-log/2fba827e-7f14-4e6d-8c48-f7b3947b8a14/static_vllm_log.txt
YIWEI_TEST_1776148137     Qwen3-Coder-30B-A3B-Instruct   RUNNING         tpu7x-8         N/A          go/bm-log/391b44fe-1082-4d28-ab16-42b1cac437b6/static_vllm_log.txt
YIWEI_TEST_1776148137     Qwen3-Coder-480B-A35B-Instruct-FP8 CREATED         tpu7x-8         N/A          go/bm-log/977b2659-4cd4-429f-a92e-ea8f817053aa/static_vllm_log.txt
YIWEI_TEST_1776148137     Qwen3-Coder-480B-A35B-Instruct-FP8 CREATED         tpu7x-8         N/A          go/bm-log/b77e7bd6-d2da-4ec2-a29b-f83a66819238/static_vllm_log.txt
``` 