### PR TITLE
Adjust tpu7x machine counts: tpu7x-2 8→6, tpu7x-8 0→1

### DIFF
--- a/terraform/gcp/ci_cd_us_central1/variables.tf
+++ b/terraform/gcp/ci_cd_us_central1/variables.tf
@@ -43,11 +43,11 @@ variable "v6e_8_count" {
 }
 
 variable "v7x_2_tt_count" {
-  default     = 8
+  default     = 6
 }
 
 variable "v7x_8_tt_count" {
-  default     = 0
+  default     = 1
 }
 
 


### PR DESCRIPTION
## Summary
- Reduce `v7x_2_tt_count` from 8 to 6 (TPU account quota)
- Increase `v7x_8_tt_count` from 0 to 1

## Test plan
- [ ] `terraform plan` shows expected count changes
- [ ] `terraform apply` succeeds
- [ ] Verify next hourly run completes on updated machine set