### PR TITLE
make agent support ENABLE_EXPERT_PARALLEL

### DIFF
--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -101,6 +101,12 @@ if [[ "${FORCE_EAGER:-,,}" == "true" ]]; then
   EXTRA_ARGS+=" --enforce-eager"
 fi
 
+# If ENABLE_EXPERT_PARALLEL is set to true (case-insensitive), append flag
+if [[ "${ENABLE_EXPERT_PARALLEL:-,,}" == "true" ]]; then
+  EXTRA_ARGS+=" --enable-expert-parallel"
+fi
+
+
 VLLM_USE_V1=1 VLLM_TORCH_PROFILER_DIR="$PROFILE_FOLDER" vllm serve $MODEL \
   --seed 42 \
   --max-num-seqs $MAX_NUM_SEQS \


### PR DESCRIPTION
This change aim to pass the ENABLE_EXPERT_PARALLEL to the agent and support `--enable-expert-parallel` flag

This is the prerequisite change for https://github.com/QiliangCui/bm-infra/pull/234