### PR TITLE
Fix vllm startup hang by detecting process exit

### DIFF
--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -109,20 +109,21 @@ VLLM_USE_V1=1 VLLM_TORCH_PROFILER_DIR="$PROFILE_FOLDER" vllm serve $MODEL \
   --no-enable-prefix-caching \
   --download_dir $DOWNLOAD_DIR \
   --max-model-len $MAX_MODEL_LEN $EXTRA_ARGS> "$VLLM_LOG" 2>&1 &
-
+VLLM_PID=$!
 
 echo "wait for 20 minutes.."
 echo
 for i in {1..120}; do
-    # TODO: detect other type of errors.
-    if grep -Fq "raise RuntimeError" "$VLLM_LOG"; then
-        echo "Detected RuntimeError, exiting."
+    # Check if vllm process has exited (crashed for any reason)
+    if ! kill -0 $VLLM_PID 2>/dev/null; then
+        echo "vllm process (PID=$VLLM_PID) has exited unexpectedly. Last 20 lines of vllm log:"
+        tail -20 "$VLLM_LOG"
         exit 1
     elif grep -Fq "Application startup complete" "$VLLM_LOG"; then
         echo "Application started"
         break
     else
-        echo "wait for 10 seconds..."
+        echo "wait for 10 seconds... (attempt $i/120)"
         sleep 10
     fi
 done


### PR DESCRIPTION
## Summary

- The startup loop previously only checked for `"raise RuntimeError"` in the vllm log to detect crashes
- If vllm exited with any other error (e.g. `ImportError`), the loop would spin silently for the full 20 minutes before timing out, causing the job to hang
- Fix by capturing `VLLM_PID=$!` after launch and checking process liveness with `kill -0` at each iteration — if the process exits for any reason, the script fails immediately with the last 20 lines of the vllm log

## Test plan

- [ ] Ran against job `82d98e97-93b1-4b36-89c8-5d0f1c6a7a68` which previously hung for 20 minutes; now fails fast (~20s) with the vllm error printed