### PR TITLE
Add gsm8k_cot lm_eval dataset

### DIFF
--- a/cases/accuracy_tt_v7.csv
+++ b/cases/accuracy_tt_v7.csv
@@ -1,2 +1,3 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts
 tpu7x-8,Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,512,4096,8,8192,mmlu,0,0,,,
+tpu7x-8,Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8,512,2048,8,2048,gsm8k_cot,0,0,,,

--- a/lm_eval/gsm8k_cot/parse_lm_eval_gsm8k_cot_results.py
+++ b/lm_eval/gsm8k_cot/parse_lm_eval_gsm8k_cot_results.py
@@ -1,0 +1,62 @@
+import argparse
+import json
+import os
+import sys
+
+
+def parse_gsm8k_cot_results(input_file):
+    """
+    Parses the raw results from an lm_eval gsm8k_cot run. Prints a
+    machine-readable JSON object to stdout for automation and a human-readable
+    summary to stderr. The aggregate score is exposed as 'gsm8k_cot_agg';
+    individual metrics are prefixed with 'gsm8k_cot_'.
+    """
+    try:
+        with open(input_file, 'r') as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from {input_file}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print(f"Error: Input file not found at {input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    results = data.get("results", {})
+    task_metrics = results.get("gsm8k_cot", {})
+
+    summary = {}
+
+    # lm_eval reports gsm8k_cot with keys like "exact_match,strict-match"
+    # and "exact_match,flexible-extract". Prefer flexible-extract as the headline
+    # since strict-match often fails on reasoning-style output (e.g. Qwen3 thinking).
+    flexible_key = "exact_match,flexible-extract"
+    strict_key = "exact_match,strict-match"
+
+    if flexible_key in task_metrics:
+        summary["gsm8k_cot_agg"] = task_metrics[flexible_key]
+        summary["gsm8k_cot_flexible_extract"] = task_metrics[flexible_key]
+    if strict_key in task_metrics:
+        summary["gsm8k_cot_strict_match"] = task_metrics[strict_key]
+        # Fall back to strict if flexible is missing
+        if "gsm8k_cot_agg" not in summary:
+            summary["gsm8k_cot_agg"] = task_metrics[strict_key]
+
+    print(json.dumps(summary))
+
+    print("\n--- GSM8K-CoT Results Summary ---", file=sys.stderr)
+    print(f"File: {os.path.basename(input_file)}", file=sys.stderr)
+    print("-" * 30, file=sys.stderr)
+    if "gsm8k_cot_agg" in summary:
+        print(f"Overall GSM8K-CoT Accuracy: {summary['gsm8k_cot_agg']:.4f}", file=sys.stderr)
+        print("-" * 30, file=sys.stderr)
+    for k, v in sorted(summary.items()):
+        if k != "gsm8k_cot_agg":
+            print(f"- {k}: {v:.4f}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Parse lm_eval gsm8k_cot results.")
+    parser.add_argument("input_file", type=str, help="Path to the input JSON file from lm_eval.")
+    args = parser.parse_args()
+
+    parse_gsm8k_cot_results(args.input_file)

--- a/lm_eval/gsm8k_cot/run.sh
+++ b/lm_eval/gsm8k_cot/run.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -ex
+
+# Change to the script's directory to ensure relative paths work correctly.
+cd "$(dirname "$0")"
+
+# --- Configuration ---
+export LOG_DIR=./results
+export MODEL_NAME=$MODEL
+export OUTPUT_PREFIX=${TASK_NAME}_$(echo $MODEL_NAME | sed 's#/#-#g')
+
+export OUTPUT_BASE_PATH=$LOG_DIR/$OUTPUT_PREFIX.json
+export ACCURACY_JSON_PATH=/workspace/gsm8k_cot_accuracy.json
+
+echo "Running lm_eval for task: $TASK_NAME"
+echo "Output will be timestamped in: $LOG_DIR"
+
+mkdir -p "$LOG_DIR"
+
+MODEL_ARGS="pretrained=$MODEL_NAME"
+MODEL_ARGS+=",tensor_parallel_size=${TP_SIZE:-${TENSOR_PARALLEL_SIZE:-8}}"
+MODEL_ARGS+=",dtype=auto"
+MODEL_ARGS+=",gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-0.98}"
+MODEL_ARGS+=",max_gen_toks=${MAX_GEN_TOKS:-256}"
+[[ -n "${MAX_NUM_SEQS:-}" ]] && MODEL_ARGS+=",max_num_seqs=$MAX_NUM_SEQS"
+[[ -n "${MAX_NUM_BATCHED_TOKENS:-}" ]] && MODEL_ARGS+=",max_num_batched_tokens=$MAX_NUM_BATCHED_TOKENS"
+[[ -n "${MAX_MODEL_LEN:-}" ]] && MODEL_ARGS+=",max_model_len=$MAX_MODEL_LEN"
+[[ -n "${DOWNLOAD_DIR:-}" ]] && MODEL_ARGS+=",download_dir=$DOWNLOAD_DIR"
+if [[ "${ENABLE_EXPERT_PARALLEL:-False}" == "True" ]]; then
+    MODEL_ARGS+=",enable_expert_parallel=True"
+fi
+
+CMD=(
+    lm_eval
+    --model vllm
+    --model_args "$MODEL_ARGS"
+    --tasks gsm8k_cot
+    --num_fewshot 8
+    --apply_chat_template
+    --batch_size auto
+    --output_path "$OUTPUT_BASE_PATH"
+)
+
+[[ -n "${LIMIT:-}" ]] && CMD+=(--limit "$LIMIT")
+
+# Execute the command, allowing stderr for error visibility
+if ! SKIP_JAX_PRECOMPILE=1 "${CMD[@]}"; then
+    echo "Error: lm_eval command failed. See output above for details."
+    exit 1
+fi
+
+echo "Finding the latest output file in $LOG_DIR with prefix ${OUTPUT_PREFIX}..."
+
+# Find the most recently modified file in the output directory that starts with the correct prefix
+LATEST_FILE=$(find "$LOG_DIR" -type f -name "${OUTPUT_PREFIX}_*.json" -printf "%T@ %p\n" | sort -nr | head -n 1 | cut -d' ' -f2-)
+
+# Check if a file was actually found
+if [ -z "$LATEST_FILE" ]; then
+    echo "Error: No matching output file found. Exiting."
+    exit 1
+fi
+
+echo "Found and using file: $LATEST_FILE"
+
+echo "Parsing results and writing to $ACCURACY_JSON_PATH..."
+python parse_lm_eval_gsm8k_cot_results.py "$LATEST_FILE" > "$ACCURACY_JSON_PATH"

--- a/scripts/agent/docker_run_bm.sh
+++ b/scripts/agent/docker_run_bm.sh
@@ -140,7 +140,7 @@ if [ "$DATASET" = "sharegpt" ]; then
   docker cp artifacts/dataset "$CONTAINER_NAME:/workspace/"
 fi
 
-if [[ "$DATASET" == "math500" || "$DATASET" == "mmlu" || "$DATASET" == "mlperf" ]]; then
+if [[ "$DATASET" == "math500" || "$DATASET" == "mmlu" || "$DATASET" == "mlperf" || "$DATASET" == "gsm8k_cot" ]]; then
   echo "Copying lm_eval directory to container..."
   docker cp lm_eval "$CONTAINER_NAME:/workspace/"
 fi

--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Datasets using lm-evaluation-harness `lm_eval`.
-LM_EVAL_DATASETS=("math500" "mmlu" "mlperf")
+LM_EVAL_DATASETS=("math500" "mmlu" "mlperf" "gsm8k_cot")
 
 # Datasets that use the internal python performance benchmark script `python benchmark_serving.py`.
 BM_INFRA_DATASETS=("custom-token" "bench-custom-token" "bench-custom-mm")


### PR DESCRIPTION
## Summary
- Add `gsm8k_cot` as a supported lm_eval accuracy dataset: new `lm_eval/gsm8k_cot/run.sh` and `parse_lm_eval_gsm8k_cot_results.py`, modeled on the mmlu equivalents.
- Register `gsm8k_cot` in `scripts/agent/run_bm.sh` `LM_EVAL_DATASETS` and in the `scripts/agent/docker_run_bm.sh` lm_eval dir copy condition.
- Add a Qwen3-Coder-480B-A35B-Instruct-FP8 gsm8k_cot case to `cases/accuracy_tt_v7.csv`.

## Details
- `run.sh` invokes `lm_eval --model vllm --tasks gsm8k_cot --num_fewshot 8 --apply_chat_template --batch_size auto`, with `max_gen_toks=256` and the usual `tensor_parallel_size` / `max_model_len` / `max_num_batched_tokens` / `enable_expert_parallel` / `gpu_memory_utilization` plumbing from existing lm_eval scripts. `LIMIT` is honored for quick runs.
- Parser exposes three keys in `RunRecord.AccuracyMetrics`:
  - `gsm8k_cot_agg` — headline (flexible-extract, falls back to strict-match)
  - `gsm8k_cot_flexible_extract`
  - `gsm8k_cot_strict_match`
- No GCS dataset download needed — gsm8k_cot is a built-in lm-eval task that fetches from HuggingFace, so `docker_run_bm.sh` `DATASETS=(...)` is unchanged.

## Test plan
- [ ] Submit a single gsm8k_cot run against Qwen3-Coder-480B-A35B-Instruct-FP8 with `LIMIT=100` via `schedule_run.sh` and confirm `RunRecord.AccuracyMetrics.gsm8k_cot_agg` is populated with a non-null float.
- [ ] Verify `static_bm_log.txt` contains the `AccuracyMetrics:` line with all three keys.
- [ ] Confirm a failing run (e.g. simulated by `LIMIT=0` or bad model) is marked `FAILED` and does not silently write empty metrics.