### PR TITLE
Reduce v7x_2_tt_count from 6 to 4

### DIFF
--- a/terraform/gcp/ci_cd_us_central1/variables.tf
+++ b/terraform/gcp/ci_cd_us_central1/variables.tf
@@ -43,7 +43,7 @@ variable "v6e_8_count" {
 }
 
 variable "v7x_2_tt_count" {
-  default     = 6
+  default     = 4
 }
 
 variable "v7x_8_tt_count" {


### PR DESCRIPTION
## Summary
- Lower `v7x_2_tt_count` default from 6 to 4 in `terraform/gcp/ci_cd_us_central1/variables.tf`.

## Test plan
- [ ] Terraform plan reflects reduced v7x-2-tt machine count