### PR TITLE
Enable TTV v7 accuracy run every 3 hours

### DIFF
--- a/scripts/scheduler/hourly_run.sh
+++ b/scripts/scheduler/hourly_run.sh
@@ -142,8 +142,13 @@ bash ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt.csv "" $TAG HOURLY_T
 echo ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7.csv \"\" $TAG HOURLY_TT '\"MODEL_IMPL_TYPE=vllm;TEMPERATURE=0\"' tt
 bash ./scripts/scheduler/create_tt_job.sh ./cases/hourly_tt_v7.csv "" $TAG HOURLY_TT "MODEL_IMPL_TYPE=vllm;TEMPERATURE=0" "tt"
 
-# TTV v7 accuracy (mmlu on tpu7x)
-# bash ./scripts/scheduler/create_tt_job.sh ./cases/accuracy_tt_v7.csv "" $TAG TT_ACCURACY "MODEL_IMPL_TYPE=vllm;ENABLE_EXPERT_PARALLEL=True;VLLM_DISABLE_SHARED_EXPERTS_STREAM=1;GPU_MEMORY_UTILIZATION=0.9" "tt"
+
+# TTV v7 accuracy (mmlu on tpu7x).
+# Will eventually run daily; for now we run more frequently (every 3 hours: 00,03,06,09,12,15,18,21).
+if (( 10#$HOUR_NOW % 3 == 0 )); then
+  echo ./scripts/scheduler/create_tt_job.sh ./cases/accuracy_tt_v7.csv \"\" $TAG DAILY_TT_ACCURACY '"MODEL_IMPL_TYPE=vllm;ENABLE_EXPERT_PARALLEL=True;VLLM_DISABLE_SHARED_EXPERTS_STREAM=1;GPU_MEMORY_UTILIZATION=0.9"' tt
+  bash ./scripts/scheduler/create_tt_job.sh ./cases/accuracy_tt_v7.csv "" $TAG DAILY_TT_ACCURACY "MODEL_IMPL_TYPE=vllm;ENABLE_EXPERT_PARALLEL=True;VLLM_DISABLE_SHARED_EXPERTS_STREAM=1;GPU_MEMORY_UTILIZATION=0.9" "tt"
+fi
 
 # torchax v7
 echo "./scripts/scheduler/create_job.sh ./cases/hourly_torchax_jax_v7.csv \"\" $TAG HOURLY_AX_JAX TPU_INFERENCE \"TPU_BACKEND_TYPE=jax;MODEL_IMPL_TYPE=vllm\" tt"


### PR DESCRIPTION
## Summary
- Enable the `accuracy_tt_v7.csv` job in `hourly_run.sh` under run type `DAILY_TT_ACCURACY` (renamed from `TT_ACCURACY`).
- Schedule it every 3 hours (00, 03, 06, 09, 12, 15, 18, 21) via `(( 10#$HOUR_NOW % 3 == 0 ))`. Will eventually drop to daily; running more frequently for now to gather signal.
- Fix the `echo` line so it mirrors the actual `bash` invocation (escaped empty `""` arg, quoted env-var blob) — output is now copy-pasteable.

## Test plan
- [x] `bash -n scripts/scheduler/hourly_run.sh` passes
- [x] Manually verified the `echo` output matches the `bash` command for `HOUR_NOW=03`
- [ ] Confirm next scheduled run at an hour matching `% 3 == 0` triggers a `DAILY_TT_ACCURACY` job