### PR TITLE
Retry git clone in hourly_run.sh to survive transient GitHub 5xx

### DIFF
--- a/scripts/scheduler/hourly_run.sh
+++ b/scripts/scheduler/hourly_run.sh
@@ -10,12 +10,34 @@ HOUR_NOW=$(TZ="$TIMEZONE" date +%H)
 echo "./scripts/cleanup_docker.sh"
 ./scripts/cleanup_docker.sh
 
+# Retry git clone to ride through transient GitHub HTTP 5xx errors. A failed
+# clone leaves repos/ incomplete and breaks every downstream job that depends
+# on the missing path, so any clone failure must be fatal after retries.
+clone_with_retry() {
+  local url="$1" dest="$2"
+  local max_attempts=4 attempt=1 sleep_s=5
+  while true; do
+    rm -rf "$dest"
+    if git clone "$url" "$dest"; then
+      return 0
+    fi
+    if (( attempt >= max_attempts )); then
+      echo "ERROR: Failed to clone $url after $max_attempts attempts" >&2
+      return 1
+    fi
+    echo "Clone attempt $attempt/$max_attempts failed for $url; retrying in ${sleep_s}s..." >&2
+    sleep "$sleep_s"
+    attempt=$(( attempt + 1 ))
+    sleep_s=$(( sleep_s * 2 ))
+  done
+}
+
 rm -rf repos/
 mkdir -p repos/
 
-git clone https://github.com/vllm-project/vllm.git repos/vllm
-git clone https://github.com/vllm-project/tpu-inference.git repos/tpu-inference
-git clone https://github.com/pytorch/xla.git repos/xla
+clone_with_retry https://github.com/vllm-project/vllm.git repos/vllm || exit 1
+clone_with_retry https://github.com/vllm-project/tpu-inference.git repos/tpu-inference || exit 1
+clone_with_retry https://github.com/pytorch/xla.git repos/xla || exit 1
 
 map_entries=(
   "https://github.com/vllm-project/vllm.git||repos/vllm"


### PR DESCRIPTION
## Summary

- Add a `clone_with_retry` helper (3 attempts, 5s/10s/20s exponential backoff) and use it for the three repo clones at the top of `hourly_run.sh`.
- Make any clone failure (after exhausting retries) fatal via `|| exit 1`, so a broken clone block fails fast instead of scheduling jobs against an incomplete `repos/` tree.

## Why

On 2026-05-05 17:00, GitHub returned HTTP 500 between the `vllm` and `tpu-inference` clones in `cuiq-vllm-dev-2`'s scheduler:

```
17:00:01  Cloning into 'repos/vllm'...                              ← OK
17:00:18  Cloning into 'repos/tpu-inference'...
17:00:24  error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
17:00:24  fatal: expected flush after ref listing
17:00:24  Cloning into 'repos/xla'...
17:00:25  remote: Internal Server Error
17:00:25  fatal: unable to access 'https://github.com/pytorch/xla.git/': The requested URL returned error: 500
```

`hourly_run.sh` had no retry and no `set -e`, so the script kept going. `repos/vllm` existed but `repos/tpu-inference` and `repos/xla` didn't. Three minutes later, `create_job.sh` (called for `hourly_torchax_jax_v7.csv` with `REPO=TPU_INFERENCE`) hit the missing local-mapping path and exited 1, taking `bm-scheduler.service` into `FAILED`.

A 3-attempt retry would have ridden out the ~1-second blip; a fatal exit when retries are exhausted gives systemd a clear signal instead of letting the run silently produce partial results.

## Test plan

- [ ] `bash -n scripts/scheduler/hourly_run.sh` (syntax check) — passes locally.
- [ ] Wait for the next hourly tick on `cuiq-vllm-dev-2` and confirm `bm-scheduler.service` is `active (running)` with all three repos present in `repos/`.
- [ ] (Optional) simulate a transient failure by temporarily mapping `https://github.com/...` to an unresolvable host and verifying the retry/backoff and final exit behavior.