### PR TITLE
Bump TT base image torch-tpu to 0.1.1.dev20260504094009

### DIFF
--- a/docker/DockerfileTT
+++ b/docker/DockerfileTT
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 # The vllm's tag: v0.19.0
 ARG VLLM_COMMIT_HASH="2a69949"
 
-ARG TORCH_VERSION="0.1.1.dev20260423092951"
+ARG TORCH_VERSION="0.1.1.dev20260504094009"
 
 #
 # Build and install vLLM

--- a/scripts/scheduler/build_tt_image.sh
+++ b/scripts/scheduler/build_tt_image.sh
@@ -12,7 +12,7 @@ export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)
 # 2. Fetch the version of torch_tpu
 # This runs a tiny container to check the version from the registry
 
-TORCH_VERSION="0.1.1.dev20260423092951"
+TORCH_VERSION="0.1.1.dev20260504094009"
 # echo "Determining torch_tpu version..."
 # TORCH_VERSION=$(docker run --rm \
 #     -e GOOGLE_ACCESS_TOKEN=$GOOGLE_ACCESS_TOKEN \


### PR DESCRIPTION
## Summary
- torchtpu-vllm main `d453893` (#161, merged 2026-05-05 14:59 PT) bumped its `pyproject.toml` pin to `torch-tpu==0.1.1.dev20260504094009`.
- `DockerfileTTV` runs `pip install --pre -e .` against torchtpu-vllm without the torch-tpu virtual-registry `--index-url`, so pip can't resolve the new pin and the docker build fails.
- Every `HOURLY_TT` / `HOURLY_DISAGG` / `DAILY_TT_ACCURACY` hourly run has failed to post any rows to Spanner since the `20260505_150002` tag (last good was `20260505_140002`); other hourly jobs (`HOURLY_JAX`, `HOURLY_AX_JAX`, `HOURLY`) are unaffected.
- This brings `DockerfileTT` and `build_tt_image.sh` in line with torchtpu-vllm main so `DockerfileTTV` inherits a satisfying torch-tpu from the base. Mirrors the fix shape of #247.

## Test plan
- [ ] Merge, then rebuild and push `tt:latest`: `./scripts/scheduler/build_tt_image.sh`
- [ ] Submit a one-off `create_tt_job.sh ./cases/hourly_tt_v7.csv "" smoke_$(date +%s) HOURLY_TT "MODEL_IMPL_TYPE=vllm;TEMPERATURE=0" tt` and confirm rows land in Spanner
- [ ] Confirm next hourly cron creates `HOURLY_TT` rows for both v6 (`hourly_tt.csv`) and v7 (`hourly_tt_v7.csv`)