### PR TITLE
Fix DockerfileNoTorchXla vllm editable build

### DIFF
--- a/docker/DockerfileNoTorchXla
+++ b/docker/DockerfileNoTorchXla
@@ -16,6 +16,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     rclone \
     ca-certificates \
+    build-essential \
+    cmake \
+    g++ \
     && rm -rf /var/lib/apt/lists/*
 
 # Build vLLM
@@ -29,7 +32,7 @@ RUN git clone $VLLM_REPO . && \
     fi
         
 RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/tpu.txt --retries 3
-RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install -e .
+RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install --no-build-isolation -e .
 
 # Install test dependencies
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e tests/vllm_test_utils


### PR DESCRIPTION
## Summary
- Hourly `tpu-inference` image build started failing with `No CMAKE_CXX_COMPILER could be found` at the `VLLM_TARGET_DEVICE=tpu pip install -e .` step in `DockerfileNoTorchXla`.
- Mirrors the upstream break that tpu-inference fixed in https://github.com/vllm-project/tpu-inference/pull/2595 (root cause: vllm-project/vllm#36517 — upstream pulled CUDA-related build deps into the isolated build env, exposing a missing C++ toolchain in the slim base image).
- Fix: `apt-get install build-essential cmake g++` and pass `--no-build-isolation` to the editable install, identical to PR #2595.

## Test plan
- [ ] Rerun the hourly tpu-inference image build and confirm the `pip install -e .` step completes
- [ ] Confirm a downstream job using the rebuilt image runs end-to-end