### PR TITLE
Keep .git in TTV docker build context

### DIFF
--- a/scripts/scheduler/build_tt_vllm_image.sh
+++ b/scripts/scheduler/build_tt_vllm_image.sh
@@ -52,6 +52,10 @@ echo "Building with $DOCKERFILE"
 
 pushd artifacts/torchtpu-vllm
 
+# Keep .git in the build context: tpu_inference uses setuptools_scm to derive
+# its version from git history, and torchtpu-vllm's .dockerignore excludes .git.
+sed -i '/^\.git$/d' .dockerignore
+
 VLLM_TARGET_DEVICE=tpu DOCKER_BUILDKIT=1 docker build \
 --build-arg max_jobs=16 \
 --build-arg USE_SCCACHE=1 \


### PR DESCRIPTION
## Summary
- torchtpu-vllm PR #200 (fab1031, "feat: ignore .git directory in Docker build context") added `.git` to torchtpu-vllm's `.dockerignore`.
- `DockerfileTTV` does `COPY . .` then `pip install --pre -e .` against `/workspace/torchtpu_vllm`. With `.git` filtered from the build context, `setuptools_scm` (used by `tpu_inference`'s `pyproject.toml` for `dynamic = ["version"]`) can't read git history and fails: `LookupError: setuptools-scm was unable to detect version for /workspace/torchtpu_vllm`.
- Fix: strip `.git` from `.dockerignore` in the build script before invoking `docker build`. The change is local to the cloned `artifacts/torchtpu-vllm` workspace; no upstream change needed.

## Test plan
- [x] Reproduced the failure end-to-end against tt commit `375f210` (the same commit the hourly was failing on).
- [x] Applied the fix, deleted local and remote stale image, re-ran `./scripts/scheduler/build_tt_vllm_image.sh 375f210` from a clean state — build succeeds and pushes `2a69949-375f210-0.1.1.dev20260515095303.vllm`.
- [x] Confirmed `setuptools_scm` derives a valid version (`tpu_inference-0.1.dev1393+g375f21010.d20260520`) once `.git` is back in the build context.