### PR TITLE
Bump TORCH_VERSION in build_tt_image.sh to match torchtpu-vllm

### DIFF
--- a/scripts/scheduler/build_tt_image.sh
+++ b/scripts/scheduler/build_tt_image.sh
@@ -12,7 +12,7 @@ export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)
 # 2. Fetch the version of torch_tpu
 # This runs a tiny container to check the version from the registry
 
-TORCH_VERSION="0.1.1.dev20260423092951"
+TORCH_VERSION="0.1.1.dev20260515095303"
 # echo "Determining torch_tpu version..."
 # TORCH_VERSION=$(docker run --rm \
 #     -e GOOGLE_ACCESS_TOKEN=$GOOGLE_ACCESS_TOKEN \


### PR DESCRIPTION
## Summary
- Hardcoded \`TORCH_VERSION\` in \`build_tt_image.sh\` was stale at \`0.1.1.dev20260423092951\`. torchtpu-vllm \`main\` now pins \`torch-tpu==0.1.1.dev20260515095303\` in \`pyproject.toml\` (after #178/#179).
- The base \`tt:latest\` image's pre-installed \`torch_tpu\` must match this pin: \`DockerfileTTV\` later runs \`pip install --pre -e .\` without any private index configured, so if pyproject's pin doesn't match what's already installed, pip tries to fetch the new wheel from PyPI and fails (only a \`0.0.0\` placeholder exists publicly).
- New \`tt:latest\` already rebuilt and pushed with the matching version; this PR brings the script in sync so any future manual rebuild lands the right pin.

## Test plan
- [x] Manually built and pushed new \`tt:latest\` with the bumped version.
- [x] Verified post-rebuild that \`docker run tt:latest pip show torch_tpu\` reports \`0.1.1.dev20260515095303\`.
- [x] Verified end-to-end \`build_tt_vllm_image.sh 375f210\` succeeds against the new base (PR #253 covers the second stacked bug).