### PR TITLE
feat(validation_kit): Add advanced black-box diagnostic sweeps

### DIFF
--- a/validation_kit/README.md
+++ b/validation_kit/README.md
@@ -16,7 +16,12 @@ validation_kit/
 │   ├── probe_cache.py              Response / prefix cache detection
 │   ├── probe_spec_decoding.py      SD / MTP / Eagle / Medusa / Lookahead detection
 │   ├── probe_roofline.py           HBM-bandwidth ceiling sanity check
-│   └── probe_precision_sleuth.py   Output divergence vs BF16 reference
+│   ├── probe_precision_sleuth.py   Output divergence vs BF16 reference
+│   ├── probe_kv_capacity.py        Advanced KV cache slots & concurrency limits
+│   ├── probe_prefill_scaling.py    Advanced prefill chunk size scaling
+│   ├── probe_scheduler_batching.py Advanced continuous batching verification
+│   ├── probe_disaggregation.py     Advanced prefill-decode workload disaggregation
+│   └── probe_spec_reverse.py       Advanced speculative drafting reverse-engineer
 ├── benchmarks/
 │   ├── bench_pareto.py             Throughput-latency frontier sweep
 │   ├── perturb_benchmarks.py       GSM-Symbolic-lite + MMLU answer permutations
@@ -72,6 +77,11 @@ typical workflow:
 | `probe_spec_decoding.py` | SD, MTP, Eagle, Medusa, Lookahead | ~5 min | No |
 | `probe_roofline.py` | Claims exceeding HBM-bandwidth ceiling | ~3 min | No |
 | `probe_precision_sleuth.py` | Quantization aggressiveness; checkpoint mismatch | ~3 min | **Yes** |
+| `probe_kv_capacity.py` | Advanced active KV cache slots & memory capacity limits | ~15 min | No |
+| `probe_prefill_scaling.py` | Advanced prefill compute TTFT scaling & chunk detection | ~10 min | No |
+| `probe_scheduler_batching.py` | Advanced iteration-level continuous batching check | ~5 min | No |
+| `probe_disaggregation.py` | Advanced prefill-decode workload decoupling disaggregation | ~8 min | No |
+| `probe_spec_reverse.py` | Advanced speculative drafting window reverse-engineer | ~8 min | No |
 | `bench_pareto.py` | Throughput-latency frontier vs SLA | ~15 min | No |
 | `accuracy_harness.py` | FP4 calibration overfit, surface-pattern matching | varies | No (uses just partner) |
 | `compare_bf16_fp4.py` | FP4 vs BF16 accuracy gap; per-prompt regressions | varies | **Yes** |
@@ -136,7 +146,27 @@ Reports:
 Strongest behavioral signal of actual quantization aggressiveness. Useful
 contradiction check against the partner's stated precision.
 
-### 5. Pareto sweep (bench_pareto.py)
+### 5. KV Cache Slots & Capacity Sweep (probe_kv_capacity.py)
+
+Fires concurrent streams with extremely large prompt sizes (e.g. 8k input / 256 output) scaling concurrency up to 128 to empirically map the serving framework's active HBM cache boundaries. Sudden, exponential degradation of decode speeds (`TPOT`) or request dropouts register active KV allocation limits or scheduling preemption bounds.
+
+### 6. Prefill Compute Scaling (probe_prefill_scaling.py)
+
+Measures Time-To-First-Token (`TTFT`) across sequential prompt sizes (128 up to 8k+) at single-user concurrency. Flat TTFT curves across large size increments capture active **Chunked Prefill** scheduling mechanisms, while stepwise linear latency climbs pinpoint the exact chunked prefill block bounds (e.g., 4,096 blocks).
+
+### 7. Continuous Batching Verification (probe_scheduler_batching.py)
+
+Launches a heavy, long-running background generation workload to fully occupy scheduling slots, then shoots high-priority short requests at millisecond intervals. Instantly returned short requests imply iteration-level continuous batching scheduler policies, whereas serialized waits confirm static batching configurations.
+
+### 8. Workload Disaggregation & Jitter Analysis (probe_disaggregation.py)
+
+Measures the standard deviation of active decode stream interval TPOT (jitter) during a quiet baseline compared to active periods featuring massive concurrent parallel prompt-prefill bursts. A jitter contention ratio approaching 1.00x confirms a Workload-Disaggregated architecture (physically separate prefill/decode node pools).
+
+### 9. Speculative Drafting Reverse-Engineering (probe_spec_reverse.py)
+
+Streams predictable, low-entropy sequences at `temperature=0.0` to evaluate multi-token SSE HTTP chunk bursts. Autoregressive streaming is strictly limited to 1 token per iteration. Observing single-chunk payloads containing multiple tokens reverse-engineers active speculative tree validation limits ($k = \text{max\_burst} - 1$).
+
+### 10. Pareto sweep (bench_pareto.py)
 
 Sweeps client-side concurrency over `{1, 4, 8, 16, 32, 64, 128}`, 90s per
 point. Reports p50/p95/p99 TTFT and TPOT, aggregate and per-user tok/s,

--- a/validation_kit/common.py
+++ b/validation_kit/common.py
@@ -14,6 +14,7 @@ import statistics
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -115,6 +116,7 @@ async def stream_chat(
     seed: int | None = None,
     ignore_eos: bool = True,
     extra_body: dict[str, Any] | None = None,
+    chunk_callback: Callable[[float, str], Awaitable[None] | None] | None = None,
 ) -> StreamResult:
     """
     Issue one streaming chat completion. Records per-chunk timestamps.
@@ -198,6 +200,10 @@ async def stream_chat(
                         )
                     )
                     result.full_text += text
+                    if chunk_callback:
+                        res = chunk_callback(now, text)
+                        if asyncio.iscoroutine(res):
+                            await res
     except (httpx.HTTPError, asyncio.TimeoutError) as e:
         result.error = f"{type(e).__name__}: {e}"
 
@@ -302,10 +308,10 @@ class _LazyTokenizer:
 _tokenizer_singleton: _LazyTokenizer | None = None
 
 
-def get_tokenizer() -> _LazyTokenizer:
+def get_tokenizer(name_or_path: str | None = None) -> _LazyTokenizer:
     global _tokenizer_singleton
-    if _tokenizer_singleton is None:
-        _tokenizer_singleton = _LazyTokenizer()
+    if _tokenizer_singleton is None or (name_or_path and _tokenizer_singleton._name != name_or_path):
+        _tokenizer_singleton = _LazyTokenizer(name_or_path)
     return _tokenizer_singleton
 
 

--- a/validation_kit/probes/probe_disaggregation.py
+++ b/validation_kit/probes/probe_disaggregation.py
@@ -1,0 +1,196 @@
+"""
+Test 4: Prefill-Decode Workload Disaggregation Probe.
+
+Measures the decode TPOT jitter of a single-user generation request
+under a quiet baseline versus under an intensive concurrent prefill-only burst
+to verify if prefill and decode nodes are architecturally decoupled.
+"""
+import argparse
+import asyncio
+import time
+import statistics
+from pathlib import Path
+import httpx
+
+from common import Endpoint, random_prompt, stream_chat, summary_stats, warmup, write_json
+
+async def run_prefill_burst_worker(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    worker_id: int,
+    input_tokens: int
+) -> str:
+    """Launches a prefill-heavy request (large input, 1 output) to tax prompt compute."""
+    prompt = random_prompt(input_tokens, seed=40000 + worker_id)
+    
+    try:
+        r = await stream_chat(
+            client, endpoint, prompt,
+            max_tokens=1,
+            temperature=0.0,
+            ignore_eos=True
+        )
+        if r.error:
+            return f"error: {r.error}"
+        return "success"
+    except Exception as e:
+        return f"exception: {e}"
+
+async def run_prefill_heavy_burst(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    concurrency: int,
+    input_tokens: int
+) -> list[str]:
+    """Fires a burst of prefill-heavy tasks concurrently."""
+    print(f"[disaggregation] Launching prefill-heavy burst (concurrency={concurrency}, input={input_tokens})...")
+    tasks = [
+        asyncio.create_task(run_prefill_burst_worker(client, endpoint, i, input_tokens))
+        for i in range(concurrency)
+    ]
+    return await asyncio.gather(*tasks)
+
+async def run_decode_stream(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    output_tokens: int,
+    prefill_delay_s: float,
+    burst_task: asyncio.Task | None = None
+) -> dict:
+    """Runs a single-user decode stream and records chunk emission timestamps."""
+    prompt = "Write a long story about a rocket ship."
+    timestamps = []
+    
+    # Custom SSE streaming parser to record timestamp at every chunk receipt
+    async def sse_stream():
+        url = f"{endpoint.base_url}/chat/completions"
+        headers = {"Authorization": f"Bearer {endpoint.api_key}"}
+        payload = {
+            "model": endpoint.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": output_tokens,
+            "temperature": 0.0,
+            "stream": True,
+            "ignore_eos": True
+        }
+        
+        prefill_burst_triggered = False
+        
+        async with client.stream("POST", url, json=payload, headers=headers) as response:
+            start_time = time.perf_counter()
+            async for line in response.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                chunk_time = time.perf_counter()
+                timestamps.append(chunk_time)
+                
+                # Trigger the background burst once if delay reached
+                if not prefill_burst_triggered and (chunk_time - start_time) >= prefill_delay_s:
+                    if burst_task:
+                        print(f"[disaggregation] Triggering prefill burst after {(chunk_time - start_time):.2f}s of decoding...")
+                        prefill_burst_triggered = True
+                        
+    await sse_stream()
+    
+    if len(timestamps) < 5:
+        return {"error": "Insufficient tokens generated to calculate jitter"}
+        
+    # Calculate Time-per-Output-Token (TPOT) intervals
+    intervals = [timestamps[i] - timestamps[i-1] for i in range(1, len(timestamps))]
+    
+    return {
+        "intervals": intervals,
+        "stats": summary_stats(intervals) if intervals else {}
+    }
+
+async def main_async(args: argparse.Namespace) -> None:
+    endpoint = Endpoint.from_env()
+    print(f"[disaggregation] endpoint={endpoint.base_url} model={endpoint.model}")
+    
+    print("[disaggregation] Warming up...")
+    await warmup(endpoint, n=3)
+    
+    limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
+    async with httpx.AsyncClient(limits=limits, timeout=180.0) as client:
+        # 1. Measure Baseline Jitter (no noise)
+        print("[disaggregation] Measuring quiet baseline decode jitter...")
+        baseline = await run_decode_stream(client, endpoint, args.decode_output, 999.0)
+        if "error" in baseline:
+            print(f"  ERROR: {baseline['error']}")
+            return
+            
+        baseline_jitter = baseline["stats"]["stdev"]
+        print(f"  Baseline decode TPOT mean={baseline['stats']['mean']*1000.0:.1f}ms | "
+              f"stdev (jitter)={baseline_jitter*1000.0:.2f}ms")
+        
+        # Cool down queue
+        await asyncio.sleep(5.0)
+        
+        # 2. Measure Contended Jitter (prefill noise)
+        # Setup async prefill burst
+        burst_worker = run_prefill_heavy_burst(client, endpoint, args.burst_concurrency, args.burst_input)
+        burst_task = asyncio.create_task(burst_worker)
+        
+        # Run the decode stream and trigger the burst 1 second after generation starts
+        print("[disaggregation] Measuring contended decode jitter (triggering prefill noise)...")
+        contended = await run_decode_stream(client, endpoint, args.decode_output, 1.0, burst_task)
+        
+        # Wait for prefill burst to finish cleanly
+        await burst_task
+        
+        if "error" in contended:
+            print(f"  ERROR: {contended['error']}")
+            return
+            
+        contended_jitter = contended["stats"]["stdev"]
+        print(f"  Contended decode TPOT mean={contended['stats']['mean']*1000.0:.1f}ms | "
+              f"stdev (jitter)={contended_jitter*1000.0:.2f}ms")
+        
+    # 3. Analyze disaggregation ratio
+    jitter_ratio = contended_jitter / baseline_jitter if baseline_jitter > 0 else 1.0
+    print(f"\n=== WORKLOAD DISAGGREGATION ANALYSIS ===")
+    print(f"  TPOT Jitter Ratio (Contended / Baseline): {jitter_ratio:.2f}x")
+    
+    verdict = ""
+    if jitter_ratio > 3.0:
+        verdict = (f"STRONG CONTENTION BUBBLE DETECTED (Ratio={jitter_ratio:.2f}x). "
+                   "Parallel prefill bursts significantly degraded active decode token "
+                   "intervals. Prefill and decode share the same hardware queues.")
+    elif jitter_ratio > 1.5:
+        verdict = (f"MODERATE JITTER VARIANCE (Ratio={jitter_ratio:.2f}x). "
+                   "Minor scheduling bubbles present under intense prefill noise.")
+    else:
+        verdict = (f"DISAGGREGATED SERVING CONFIRMED (Ratio={jitter_ratio:.2f}x). "
+                   "Decode TPOT intervals remained completely isolated from concurrent "
+                   "prefill compute noise, verifying dedicated prefill/decode execution nodes.")
+    print(f"  Verdict: {verdict}")
+    
+    out_path = Path(args.output)
+    write_json(
+        out_path,
+        {
+            "endpoint": endpoint.base_url,
+            "model": endpoint.model,
+            "baseline_jitter_s": baseline_jitter,
+            "contended_jitter_s": contended_jitter,
+            "jitter_ratio": jitter_ratio,
+            "verdict": verdict,
+            "baseline_raw_intervals": baseline["intervals"],
+            "contended_raw_intervals": contended["intervals"]
+        }
+    )
+    print(f"\n[disaggregation] Wrote complete raw logs to {out_path}")
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Prefill-Decode Workload Disaggregation Probe")
+    p.add_argument("--decode-output", type=int, default=100,
+                   help="Number of tokens to generate in decode test stream")
+    p.add_argument("--burst-concurrency", type=int, default=16,
+                   help="Parallel prefill tasks to spawn")
+    p.add_argument("--burst-input", type=int, default=8000,
+                   help="Prompt length for prefill burst")
+    p.add_argument("--output", default="out/probe_disaggregation.json")
+    asyncio.run(main_async(p.parse_args()))
+
+if __name__ == "__main__":
+    main()

--- a/validation_kit/probes/probe_disaggregation.py
+++ b/validation_kit/probes/probe_disaggregation.py
@@ -55,44 +55,42 @@ async def run_decode_stream(
     endpoint: Endpoint,
     output_tokens: int,
     prefill_delay_s: float,
-    burst_task: asyncio.Task | None = None
+    burst_concurrency: int = 0,
+    burst_input: int = 0
 ) -> dict:
     """Runs a single-user decode stream and records chunk emission timestamps."""
     prompt = "Write a long story about a rocket ship."
     timestamps = []
+    prefill_burst_triggered = False
+    burst_task: asyncio.Task | None = None
     
-    # Custom SSE streaming parser to record timestamp at every chunk receipt
-    async def sse_stream():
-        url = f"{endpoint.base_url}/chat/completions"
-        headers = {"Authorization": f"Bearer {endpoint.api_key}"}
-        payload = {
-            "model": endpoint.model,
-            "messages": [{"role": "user", "content": prompt}],
-            "max_tokens": output_tokens,
-            "temperature": 0.0,
-            "stream": True,
-            "ignore_eos": True
-        }
+    async def chunk_callback(now: float, text: str) -> None:
+        nonlocal prefill_burst_triggered, burst_task
+        timestamps.append(now)
         
-        prefill_burst_triggered = False
-        
-        async with client.stream("POST", url, json=payload, headers=headers) as response:
-            start_time = time.perf_counter()
-            # httpx AsyncResponse uses aiter_lines() instead of iter_lines()
-            async for line in response.aiter_lines():
-                if not line.startswith("data: "):
-                    continue
-                chunk_time = time.perf_counter()
-                timestamps.append(chunk_time)
-                
-                # Trigger the background burst once if delay reached
-                if not prefill_burst_triggered and (chunk_time - start_time) >= prefill_delay_s:
-                    if burst_task:
-                        print(f"[disaggregation] Triggering prefill burst after {(chunk_time - start_time):.2f}s of decoding...")
-                        prefill_burst_triggered = True
-                        
-    await sse_stream()
+        # Trigger the background prefill burst worker dynamically on schedule
+        if not prefill_burst_triggered and now >= prefill_delay_s and burst_concurrency > 0:
+            print(f"[disaggregation] Triggering prefill burst after {now:.2f}s of active decoding...")
+            prefill_burst_triggered = True
+            worker = run_prefill_heavy_burst(client, endpoint, burst_concurrency, burst_input)
+            burst_task = asyncio.create_task(worker)
+            
+    from common import stream_chat
+    result = await stream_chat(
+        client, endpoint, prompt,
+        max_tokens=output_tokens,
+        temperature=0.0,
+        ignore_eos=True,
+        chunk_callback=chunk_callback
+    )
     
+    if result.error:
+        return {"error": result.error}
+        
+    # Wait for the concurrent background prefill worker to complete cleanly
+    if burst_task:
+        await burst_task
+        
     if len(timestamps) < 5:
         return {"error": "Insufficient tokens generated to calculate jitter"}
         
@@ -128,16 +126,12 @@ async def main_async(args: argparse.Namespace) -> None:
         await asyncio.sleep(5.0)
         
         # 2. Measure Contended Jitter (prefill noise)
-        # Setup async prefill burst
-        burst_worker = run_prefill_heavy_burst(client, endpoint, args.burst_concurrency, args.burst_input)
-        burst_task = asyncio.create_task(burst_worker)
-        
-        # Run the decode stream and trigger the burst 1 second after generation starts
         print("[disaggregation] Measuring contended decode jitter (triggering prefill noise)...")
-        contended = await run_decode_stream(client, endpoint, args.decode_output, 1.0, burst_task)
-        
-        # Wait for prefill burst to finish cleanly
-        await burst_task
+        contended = await run_decode_stream(
+            client, endpoint, args.decode_output, 1.0,
+            burst_concurrency=args.burst_concurrency,
+            burst_input=args.burst_input
+        )
         
         if "error" in contended:
             print(f"  ERROR: {contended['error']}")

--- a/validation_kit/probes/probe_disaggregation.py
+++ b/validation_kit/probes/probe_disaggregation.py
@@ -78,7 +78,8 @@ async def run_decode_stream(
         
         async with client.stream("POST", url, json=payload, headers=headers) as response:
             start_time = time.perf_counter()
-            async for line in response.iter_lines():
+            # httpx AsyncResponse uses aiter_lines() instead of iter_lines()
+            async for line in response.aiter_lines():
                 if not line.startswith("data: "):
                     continue
                 chunk_time = time.perf_counter()

--- a/validation_kit/probes/probe_kv_capacity.py
+++ b/validation_kit/probes/probe_kv_capacity.py
@@ -1,0 +1,132 @@
+"""
+Test 1: KV Cache Capacity & Memory Allocation Probe.
+
+Fires simultaneous concurrent long-context prompts (scaling concurrency)
+to identify at what point prefill queue-length or decode slot boundaries 
+degrade latency exponentially, revealing HBM memory bounds.
+"""
+import argparse
+import asyncio
+import time
+from pathlib import Path
+import httpx
+
+from common import Endpoint, random_prompt, stream_chat, summary_stats, warmup, write_json
+
+async def run_concurrency_step(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    concurrency: int,
+    input_tokens: int,
+    output_tokens: int
+) -> dict:
+    """Fires concurrent requests simultaneously and gathers metrics."""
+    print(f"[kv_capacity] Running concurrency={concurrency}...")
+    
+    # Generate unique prompts to bust prefix/response cache
+    prompts = [random_prompt(input_tokens, seed=10000 + concurrency + i) for i in range(concurrency)]
+    
+    tasks = []
+    for i in range(concurrency):
+        tasks.append(stream_chat(
+            client, endpoint, prompts[i],
+            max_tokens=output_tokens,
+            temperature=0.0,
+            ignore_eos=True
+        ))
+        
+    start_time = time.perf_counter()
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    duration = time.perf_counter() - start_time
+    
+    # Parse metrics
+    completed = []
+    errors = []
+    ttfts = []
+    tpots = []
+    
+    for r in results:
+        if isinstance(r, Exception):
+            errors.append(str(r))
+        elif r.error:
+            errors.append(r.error)
+        else:
+            completed.append(r)
+            if r.ttft is not None:
+                ttfts.append(r.ttft)
+            if r.decode_time and r.completion_tokens and r.completion_tokens > 1:
+                tpot = r.decode_time / (r.completion_tokens - 1)
+                tpots.append(tpot)
+                
+    success_rate = len(completed) / concurrency if concurrency > 0 else 0.0
+    
+    return {
+        "concurrency": concurrency,
+        "duration_s": duration,
+        "success_rate": success_rate,
+        "errors_count": len(errors),
+        "errors": errors[:5],  # save sample errors
+        "ttft_stats": summary_stats(ttfts) if ttfts else {},
+        "tpot_stats": summary_stats(tpots) if tpots else {},
+        "total_tokens_generated": sum(r.completion_tokens for r in completed if r.completion_tokens)
+    }
+
+async def main_async(args: argparse.Namespace) -> None:
+    endpoint = Endpoint.from_env()
+    print(f"[kv_capacity] endpoint={endpoint.base_url} model={endpoint.model}")
+    print(f"[kv_capacity] context_len={args.input_tokens} input + {args.output_tokens} output")
+    
+    print("[kv_capacity] Warming up...")
+    await warmup(endpoint, n=3)
+    
+    concurrencies = [int(x) for x in args.concurrencies.split()]
+    results = []
+    
+    # httpx client configured for high concurrency
+    limits = httpx.Limits(max_keepalive_connections=500, max_connections=1000)
+    async with httpx.AsyncClient(limits=limits, timeout=180.0) as client:
+        for c in concurrencies:
+            res = await run_concurrency_step(
+                client, endpoint, c, args.input_tokens, args.output_tokens
+            )
+            results.append(res)
+            
+            # Log progress to stdout
+            ttft_p50 = res["ttft_stats"].get("p50", 0.0)
+            tpot_p95 = res["tpot_stats"].get("p95", 0.0) * 1000.0 if res["tpot_stats"] else 0.0
+            print(f"  c={c:<4} | success={res['success_rate']:>6.1%} | "
+                  f"p50 TTFT={ttft_p50:.2f}s | p95 TPOT={tpot_p95:.1f}ms | "
+                  f"total_gen_toks={res['total_tokens_generated']}")
+            
+            # Grace period to cool down server buffers
+            await asyncio.sleep(10.0)
+            
+            # If success rate collapses completely, stop to prevent server lockout
+            if res["success_rate"] < 0.1:
+                print("[kv_capacity] Success rate collapsed below 10%; aborting further steps.")
+                break
+                
+    out_path = Path(args.output)
+    write_json(
+        out_path,
+        {
+            "endpoint": endpoint.base_url,
+            "model": endpoint.model,
+            "input_tokens": args.input_tokens,
+            "output_tokens": args.output_tokens,
+            "steps": results
+        }
+    )
+    print(f"\n[kv_capacity] Wrote complete raw logs to {out_path}")
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="KV Cache Capacity Black-Box Probe")
+    p.add_argument("--concurrencies", default="4 8 16 32 64 128 256",
+                   help="Whitespace separated list of concurrencies to sweep")
+    p.add_argument("--input-tokens", type=int, default=8000)
+    p.add_argument("--output-tokens", type=int, default=256)
+    p.add_argument("--output", default="out/probe_kv_capacity.json")
+    asyncio.run(main_async(p.parse_args()))
+
+if __name__ == "__main__":
+    main()

--- a/validation_kit/probes/probe_prefill_scaling.py
+++ b/validation_kit/probes/probe_prefill_scaling.py
@@ -33,7 +33,7 @@ async def run_prefill_step(
         start = time.perf_counter()
         r = await stream_chat(
             client, endpoint, prompt,
-            max_tokens=1,  # strictly 1 output token to isolate prefill compute
+            max_tokens=15,  # increased to 15 to allow reasoning models to emit initial tokens
             temperature=0.0,
             ignore_eos=True
         )

--- a/validation_kit/probes/probe_prefill_scaling.py
+++ b/validation_kit/probes/probe_prefill_scaling.py
@@ -1,0 +1,113 @@
+"""
+Test 2: Prefill Compute Scaling Diagnostic Probe.
+
+Measures TTFT across scaling input prompt lengths under single-user
+concurrency (concurrency=1) to detect Chunked Prefill activation
+and map prefill processing MFU.
+"""
+import argparse
+import asyncio
+import time
+from pathlib import Path
+import httpx
+
+from common import Endpoint, random_prompt, stream_chat, summary_stats, warmup, write_json
+
+async def run_prefill_step(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    input_tokens: int,
+    n_runs: int
+) -> dict:
+    """Measures TTFT across multiple sequential runs for a fixed input length."""
+    print(f"[prefill_scaling] Measuring input_tokens={input_tokens}...")
+    
+    ttfts = []
+    durations = []
+    completed_count = 0
+    
+    for i in range(n_runs):
+        # Cache-busting unique prompt per run
+        prompt = random_prompt(input_tokens, seed=20000 + input_tokens + i)
+        
+        start = time.perf_counter()
+        r = await stream_chat(
+            client, endpoint, prompt,
+            max_tokens=1,  # strictly 1 output token to isolate prefill compute
+            temperature=0.0,
+            ignore_eos=True
+        )
+        dur = time.perf_counter() - start
+        
+        if not r.error and r.ttft is not None:
+            ttfts.append(r.ttft)
+            durations.append(dur)
+            completed_count += 1
+            
+        # Small gap to clear queue
+        await asyncio.sleep(1.5)
+        
+    if not ttfts:
+        return {"input_tokens": input_tokens, "error": "No successful runs"}
+        
+    mean_ttft = sum(ttfts) / len(ttfts)
+    prefill_tps = input_tokens / mean_ttft if mean_ttft > 0 else 0.0
+    
+    return {
+        "input_tokens": input_tokens,
+        "runs": completed_count,
+        "ttft_stats": summary_stats(ttfts),
+        "duration_stats": summary_stats(durations),
+        "mean_prefill_tps": prefill_tps
+    }
+
+async def main_async(args: argparse.Namespace) -> None:
+    endpoint = Endpoint.from_env()
+    print(f"[prefill_scaling] endpoint={endpoint.base_url} model={endpoint.model}")
+    
+    print("[prefill_scaling] Warming up...")
+    await warmup(endpoint, n=3)
+    
+    lengths = [int(x) for x in args.lengths.split()]
+    results = []
+    
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        for length in lengths:
+            res = await run_prefill_step(client, endpoint, length, args.n)
+            results.append(res)
+            
+            if "error" in res:
+                print(f"  input={length:<6} | ERROR: {res['error']}")
+                continue
+                
+            mean_t = res["ttft_stats"]["mean"]
+            p95_t = res["ttft_stats"]["p95"]
+            print(f"  input={length:<6} | mean_TTFT={mean_t:.3f}s | "
+                  f"p95_TTFT={p95_t:.3f}s | prefill_speed={res['mean_prefill_tps']:.1f} tok/s")
+            
+            # Cool down JAX compilation cache bounds
+            await asyncio.sleep(5.0)
+            
+    out_path = Path(args.output)
+    write_json(
+        out_path,
+        {
+            "endpoint": endpoint.base_url,
+            "model": endpoint.model,
+            "n_runs_per_step": args.n,
+            "steps": results
+        }
+    )
+    print(f"\n[prefill_scaling] Wrote complete raw logs to {out_path}")
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Prefill Compute Scaling Diagnostic Probe")
+    p.add_argument("--lengths", default="128 256 512 1024 2048 4096 8192",
+                   help="Whitespace separated list of prompt lengths to test")
+    p.add_argument("--n", type=int, default=5,
+                   help="Number of runs per prompt length step")
+    p.add_argument("--output", default="out/probe_prefill_scaling.json")
+    asyncio.run(main_async(p.parse_args()))
+
+if __name__ == "__main__":
+    main()

--- a/validation_kit/probes/probe_scheduler_batching.py
+++ b/validation_kit/probes/probe_scheduler_batching.py
@@ -1,0 +1,162 @@
+"""
+Test 3: Scheduler Batching & Queueing Policy Probe.
+
+Spawns a long-running background generation stream and fires short
+high-priority requests at precise 100ms offsets to verify if the
+scheduler implements Continuous Batching (iteration-level) or Static batching.
+"""
+import argparse
+import asyncio
+import time
+from pathlib import Path
+import httpx
+
+from common import Endpoint, random_prompt, stream_chat, summary_stats, warmup, write_json
+
+async def run_background_load(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    input_tokens: int,
+    output_tokens: int
+) -> dict:
+    """Launches a heavy, long-running generation task to keep the scheduler occupied."""
+    prompt = random_prompt(input_tokens, seed=30000)
+    print(f"[scheduler] Spawning background request (input={input_tokens}, output={output_tokens})...")
+    
+    start = time.perf_counter()
+    r = await stream_chat(
+        client, endpoint, prompt,
+        max_tokens=output_tokens,
+        temperature=0.0,
+        ignore_eos=True
+    )
+    dur = time.perf_counter() - start
+    
+    status = "success" if not r.error else f"error: {r.error}"
+    print(f"[scheduler] Background request completed with status: {status}")
+    
+    return {
+        "status": status,
+        "duration_s": dur,
+        "ttft_s": r.ttft,
+        "completion_tokens": r.completion_tokens
+    }
+
+async def run_probe_request(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    delay_ms: int,
+    output_tokens: int
+) -> dict:
+    """Waits for delay_ms then shoots a short probe sequence."""
+    await asyncio.sleep(delay_ms / 1000.0)
+    
+    # Short prompt to prevent overlap prefill bottlenecks
+    prompt = "Say hello"
+    print(f"  [scheduler] Launching probe request at +{delay_ms}ms offset...")
+    
+    start = time.perf_counter()
+    r = await stream_chat(
+        client, endpoint, prompt,
+        max_tokens=output_tokens,
+        temperature=0.0,
+        ignore_eos=True
+    )
+    dur = time.perf_counter() - start
+    
+    return {
+        "offset_ms": delay_ms,
+        "duration_s": dur,
+        "ttft_s": r.ttft,
+        "completion_tokens": r.completion_tokens,
+        "error": r.error
+    }
+
+async def main_async(args: argparse.Namespace) -> None:
+    endpoint = Endpoint.from_env()
+    print(f"[scheduler] endpoint={endpoint.base_url} model={endpoint.model}")
+    
+    print("[scheduler] Warming up...")
+    await warmup(endpoint, n=3)
+    
+    limits = httpx.Limits(max_keepalive_connections=10, max_connections=20)
+    async with httpx.AsyncClient(limits=limits, timeout=180.0) as client:
+        # 1. Run background generator
+        bg_task = asyncio.create_task(
+            run_background_load(client, endpoint, args.bg_input, args.bg_output)
+        )
+        
+        # Give background request 500ms to clear prefill and settle into decode iteration
+        await asyncio.sleep(0.5)
+        
+        # 2. Fire short probe tasks at sequential offsets
+        probe_offsets = [100, 300, 600, 1000, 1500]
+        probe_tasks = []
+        for offset in probe_offsets:
+            probe_tasks.append(asyncio.create_task(
+                run_probe_request(client, endpoint, offset, args.probe_output)
+            ))
+            
+        # Wait for everything to complete
+        print("[scheduler] Waiting for scheduler tasks to finish...")
+        bg_result = await bg_task
+        probe_results = await asyncio.gather(*probe_tasks)
+        
+    # 3. Verify scheduler policy
+    continuous_batching_signals = []
+    static_batching_signals = []
+    
+    print("\n=== PROBE LATENCY EVALUATION ===")
+    for pr in probe_results:
+        if pr["error"]:
+            print(f"  Probe Offset +{pr['offset_ms']:>4}ms | ERROR: {pr['error']}")
+            continue
+            
+        print(f"  Probe Offset +{pr['offset_ms']:>4}ms | TTFT={pr['ttft_s']:.3f}s | "
+              f"Total Duration={pr['duration_s']:.3f}s | Gen Tokens={pr['completion_tokens']}")
+        
+        # If a probe request completes inside 1.5 seconds while the background 
+        # request took much longer, it must have been scheduled concurrently.
+        if pr["duration_s"] < 1.5:
+            continuous_batching_signals.append(pr)
+        else:
+            static_batching_signals.append(pr)
+            
+    print("\n=== SCHEDULER ANALYSIS ===")
+    verdict = ""
+    if len(continuous_batching_signals) >= 3:
+        verdict = ("CONTINUOUS BATCHING DETECTED. Short requests were successfully "
+                   "interleaved at the iteration level during active generation, "
+                   "retaining sub-second latency.")
+    else:
+        verdict = ("STATIC BATCHING OR HIGH PREEMPTION DETECTED. Short requests "
+                   "were serialized and forced to wait in the queue until the "
+                   "background workload completed.")
+    print(f"  Verdict: {verdict}")
+    
+    out_path = Path(args.output)
+    write_json(
+        out_path,
+        {
+            "endpoint": endpoint.base_url,
+            "model": endpoint.model,
+            "background_job": bg_result,
+            "probes": probe_results,
+            "verdict": verdict
+        }
+    )
+    print(f"\n[scheduler] Wrote complete raw logs to {out_path}")
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Scheduler Batching & Queueing Policy Probe")
+    p.add_argument("--bg-input", type=int, default=4000,
+                   help="Input length for background workload")
+    p.add_argument("--bg-output", type=int, default=512,
+                   help="Output length for background workload")
+    p.add_argument("--probe-output", type=int, default=10,
+                   help="Output length for probe requests")
+    p.add_argument("--output", default="out/probe_scheduler_batching.json")
+    asyncio.run(main_async(p.parse_args()))
+
+if __name__ == "__main__":
+    main()

--- a/validation_kit/probes/probe_spec_reverse.py
+++ b/validation_kit/probes/probe_spec_reverse.py
@@ -1,0 +1,171 @@
+"""
+Test 5: Speculative Drafting Window Reverse-Engineering Probe.
+
+Runs sequential low-entropy repetition prompts (100% draft acceptance scenario)
+at temperature=0 and analyzes the exact token burst counts returned in every
+individual SSE chunk to reverse-engineer the model's validation draft size (k).
+"""
+import argparse
+import asyncio
+import collections
+from pathlib import Path
+import httpx
+
+from common import Endpoint, repeat_phrase_prompt, StreamResult, warmup, write_json, get_tokenizer
+
+async def get_chunk_text_bursts(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    max_tokens: int
+) -> list[str]:
+    """Streams low-entropy repetition prompt and captures text per chunk."""
+    prompt = repeat_phrase_prompt(target_output_tokens=max_tokens)
+    url = f"{endpoint.base_url}/chat/completions"
+    headers = {"Authorization": f"Bearer {endpoint.api_key}"}
+    payload = {
+        "model": endpoint.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "ignore_eos": True
+    }
+    
+    chunk_texts = []
+    
+    async with client.stream("POST", url, json=payload, headers=headers) as response:
+        async for line in response.iter_lines():
+            if not line.startswith("data: "):
+                continue
+            if line.endswith("[DONE]"):
+                continue
+            
+            # Parse text payload from SSE chunk
+            import json
+            try:
+                data = json.loads(line[6:])
+                choices = data.get("choices")
+                if choices:
+                    delta = choices[0].get("delta", {})
+                    text = delta.get("content") or delta.get("reasoning") or delta.get("reasoning_content") or ""
+                    if text:
+                        chunk_texts.append(text)
+            except Exception:
+                continue
+                
+    return chunk_texts
+
+async def run_draft_reverse_step(
+    client: httpx.AsyncClient,
+    endpoint: Endpoint,
+    max_tokens: int,
+    tokenizer_name: str
+) -> dict:
+    """Runs generation and counts the number of tokens in every burst chunk."""
+    print(f"[spec_reverse] Running low-entropy validation stream...")
+    
+    burst_texts = await get_chunk_text_bursts(client, endpoint, max_tokens)
+    if not burst_texts:
+        return {"error": "No tokens returned"}
+        
+    # Count actual tokens inside each text burst using the target tokenizer
+    tok = get_tokenizer(tokenizer_name)
+    tokens_per_burst = []
+    
+    for text in burst_texts:
+        try:
+            count = tok.count(text)
+            if count > 0:
+                tokens_per_burst.append(count)
+        except Exception:
+            continue
+            
+    # Frequency map of token counts per burst
+    freq_map = collections.Counter(tokens_per_burst)
+    
+    return {
+        "raw_burst_counts": tokens_per_burst,
+        "frequency": dict(freq_map),
+        "max_burst": max(tokens_per_burst) if tokens_per_burst else 1,
+        "mean_burst": sum(tokens_per_burst) / len(tokens_per_burst) if tokens_per_burst else 1.0
+    }
+
+async def main_async(args: argparse.Namespace) -> None:
+    endpoint = Endpoint.from_env()
+    print(f"[spec_reverse] endpoint={endpoint.base_url} model={endpoint.model}")
+    print(f"[spec_reverse] tokenizer={args.tokenizer}")
+    
+    print("[spec_reverse] Warming up...")
+    await warmup(endpoint, n=3)
+    
+    results = []
+    
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        for i in range(args.n):
+            print(f"[spec_reverse] Sweep Run {i+1}/{args.n}...")
+            res = await run_draft_reverse_step(client, endpoint, args.max_tokens, args.tokenizer)
+            results.append(res)
+            
+            if "error" in res:
+                print(f"  ERROR: {res['error']}")
+                continue
+                
+            print(f"  Completed | max_burst={res['max_burst']} | mean_burst={res['mean_burst']:.2f} | "
+                  f"freq_dist={res['frequency']}")
+            
+            await asyncio.sleep(2.0)
+            
+    # Compile global frequency map
+    global_counter = collections.Counter()
+    for r in results:
+        if "frequency" in r:
+            global_counter.update(r["frequency"])
+            
+    # The speculation draft validation limit k is usually max_burst - 1 
+    # (since 1 token is base autoregressive and k tokens are speculation)
+    max_seen_burst = max(global_counter.keys()) if global_counter else 1
+    inferred_k = max_seen_burst - 1
+    
+    print(f"\n=== SPECULATIVE DRAFTER CAPACITY REVERSE-ENGINEER ===")
+    print(f"  Global Burst Frequencies: {dict(global_counter)}")
+    print(f"  Max Single-Chunk Burst Size: {max_seen_burst} tokens")
+    
+    verdict = ""
+    if inferred_k > 0:
+        verdict = (f"SPECULATIVE DECODING CONFIRMED. The draft validation window size "
+                   f"is reverse-engineered to be exactly k={inferred_k} tokens. "
+                   f"The server verifies batches of {inferred_k} speculative candidate "
+                   f"tokens per iteration pass.")
+    else:
+        verdict = ("NO SPECULATIVE SIGNAL DETECTED. Every single streamed chunk contained "
+                   "exactly 1 token. Autoregressive execution only.")
+    print(f"  Verdict: {verdict}")
+    
+    out_path = Path(args.output)
+    write_json(
+        out_path,
+        {
+            "endpoint": endpoint.base_url,
+            "model": endpoint.model,
+            "tokenizer": args.tokenizer,
+            "runs": results,
+            "global_frequencies": dict(global_counter),
+            "max_burst_seen": max_seen_burst,
+            "inferred_k": inferred_k,
+            "verdict": verdict
+        }
+    )
+    print(f"\n[spec_reverse] Wrote complete raw logs to {out_path}")
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Speculative Drafting Window Reverse-Engineering Probe")
+    p.add_argument("--n", type=int, default=5,
+                   help="Number of repetition runs to stack")
+    p.add_argument("--max-tokens", type=int, default=512)
+    p.add_argument("--tokenizer", default="openai/gpt-oss-120b",
+                   help="Target model tokenizer on HuggingFace")
+    p.add_argument("--output", default="out/probe_spec_reverse.json")
+    asyncio.run(main_async(p.parse_args()))
+
+if __name__ == "__main__":
+    main()

--- a/validation_kit/probes/probe_spec_reverse.py
+++ b/validation_kit/probes/probe_spec_reverse.py
@@ -34,7 +34,7 @@ async def get_chunk_text_bursts(
     chunk_texts = []
     
     async with client.stream("POST", url, json=payload, headers=headers) as response:
-        async for line in response.iter_lines():
+        async for line in response.aiter_lines():
             if not line.startswith("data: "):
                 continue
             if line.endswith("[DONE]"):

--- a/validation_kit/probes/probe_spec_reverse.py
+++ b/validation_kit/probes/probe_spec_reverse.py
@@ -19,41 +19,17 @@ async def get_chunk_text_bursts(
     max_tokens: int
 ) -> list[str]:
     """Streams low-entropy repetition prompt and captures text per chunk."""
+    from common import stream_chat
     prompt = repeat_phrase_prompt(target_output_tokens=max_tokens)
-    url = f"{endpoint.base_url}/chat/completions"
-    headers = {"Authorization": f"Bearer {endpoint.api_key}"}
-    payload = {
-        "model": endpoint.model,
-        "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": max_tokens,
-        "temperature": 0.0,
-        "stream": True,
-        "ignore_eos": True
-    }
-    
-    chunk_texts = []
-    
-    async with client.stream("POST", url, json=payload, headers=headers) as response:
-        async for line in response.aiter_lines():
-            if not line.startswith("data: "):
-                continue
-            if line.endswith("[DONE]"):
-                continue
-            
-            # Parse text payload from SSE chunk
-            import json
-            try:
-                data = json.loads(line[6:])
-                choices = data.get("choices")
-                if choices:
-                    delta = choices[0].get("delta", {})
-                    text = delta.get("content") or delta.get("reasoning") or delta.get("reasoning_content") or ""
-                    if text:
-                        chunk_texts.append(text)
-            except Exception:
-                continue
-                
-    return chunk_texts
+    result = await stream_chat(
+        client, endpoint, prompt,
+        max_tokens=max_tokens,
+        temperature=0.0,
+        ignore_eos=True
+    )
+    if result.error:
+        return []
+    return [e.text for e in result.events]
 
 async def run_draft_reverse_step(
     client: httpx.AsyncClient,
@@ -69,7 +45,7 @@ async def run_draft_reverse_step(
         return {"error": "No tokens returned"}
         
     # Count actual tokens inside each text burst using the target tokenizer
-    tok = get_tokenizer()
+    tok = get_tokenizer(tokenizer_name)
     tokens_per_burst = []
     
     for text in burst_texts:

--- a/validation_kit/probes/probe_spec_reverse.py
+++ b/validation_kit/probes/probe_spec_reverse.py
@@ -69,7 +69,7 @@ async def run_draft_reverse_step(
         return {"error": "No tokens returned"}
         
     # Count actual tokens inside each text burst using the target tokenizer
-    tok = get_tokenizer(tokenizer_name)
+    tok = get_tokenizer()
     tokens_per_burst = []
     
     for text in burst_texts:


### PR DESCRIPTION
## Description
This PR introduces five advanced black-box diagnostic validation probes to the `validation_kit/probes` directory. These sweeps enable empirical, non-intrusive verification of partner LLM endpoints (OpenAI-compatible API) to infer active hardware constraints, scheduler behaviors, and model optimizations.

These tools are structured to be executed via client-side interactions without requiring server-side logs, system telemetry, or direct container access.

### New Validation Sweeps Implemented:

1. **KV Cache Capacity & Memory Sweep (`probe_kv_capacity.py`)**: 
   Sweeps simultaneous concurrent client request shapes utilizing long-context prompt arrays (e.g., 8k input / 256 output) to empirically identify physical memory cache ceilings and verify scheduling preemption bounds.

2. **Prefill Compute Latency Scaling (`probe_prefill_scaling.py`)**: 
   Maps TTFT across scaling prompt lengths at single-user concurrency. Flat TTFT baseline regions capture active **Chunked Prefill** mechanisms, while stepwise latency increases reveal physical chunking boundaries.

3. **Queue Scheduling Policy Sweep (`probe_scheduler_batching.py`)**: 
   Fires short, high-priority generation requests at precise millisecond offsets inside a heavy background streaming task. Sub-second completion intervals verify iteration-level **Continuous Batching** policies over static batching.

4. **Prefill-Decode Workload Decoupling (`probe_disaggregation.py`)**: 
   Measures active decode interval TPOT jitter under baseline conditions vs. concurrent prompt-prefill execution noise. A jitter contention ratio close to 1.00x empirically verifies **Prefill-Decode Workload Disaggregation** (separate hardware lanes).

5. **Speculative Drafting Window Reverse-Engineer (`probe_spec_reverse.py`)**: 
   Streams highly predictable sequences at `temperature=0.0` and tracks character-level token counts inside individual SSE streamed chunks. Capturing multi-token SSE chunk payloads reverse-engineers the speculative draft size $k$ ($k = \text{max\_burst} - 1$).