### PR TITLE
fix(validation_kit): JAX-server compatibility + entropy probe kernel-confound fix

### DIFF
--- a/validation_kit/README.md
+++ b/validation_kit/README.md
@@ -40,6 +40,10 @@ export PARTNER_TOKENIZER=openai/gpt-oss-120b   # for tokens-per-chunk
 export REFERENCE_BASE_URL=http://your-vllm:8000/v1
 export REFERENCE_MODEL=openai/gpt-oss-120b
 
+# Optional: drop the `seed` request param. Some servers (notably JAX-based
+# stacks) reject `seed` with a 400; set this to keep probes working.
+export VK_DROP_SEED=1
+
 ./run_all.sh --chip-count 8 --hardware ironwood --precision default
 ```
 

--- a/validation_kit/common.py
+++ b/validation_kit/common.py
@@ -131,7 +131,7 @@ async def stream_chat(
         "stream": True,
         "stream_options": {"include_usage": True},
     }
-    if seed is not None:
+    if seed is not None and os.environ.get("VK_DROP_SEED", "0") != "1":
         body["seed"] = seed
     if ignore_eos:
         # vLLM / SGLang accept this; some servers ignore. Harmless if ignored.

--- a/validation_kit/probes/probe_spec_decoding.py
+++ b/validation_kit/probes/probe_spec_decoding.py
@@ -48,13 +48,22 @@ async def run_entropy_pair(
     max_tokens: int,
     seed: int,
 ) -> tuple[StreamResult, StreamResult]:
-    """Run one low-entropy and one high-entropy request at fixed output length."""
+    """Run one low-entropy and one high-entropy request at fixed output length.
+
+    The low-entropy request uses temperature=0.01 (not 0.0) so it is classified
+    as RANDOM by vLLM/tpu-inference and goes through the same sampling kernel
+    as the high-entropy request. Otherwise stacks with a separate all-greedy
+    fast-path (do_sampling=False -> argmax only, skipping topk/topp/categorical)
+    produce a per-token-compute gap that's indistinguishable from a true
+    SD-acceptance gap. At T=0.01 the sample distribution is essentially a delta
+    at the argmax, so output remains functionally greedy.
+    """
     low = await stream_chat(
         client,
         endpoint,
         repeat_phrase_prompt(target_output_tokens=max_tokens),
         max_tokens=max_tokens,
-        temperature=0.0,
+        temperature=0.01,
         ignore_eos=True,
     )
     high = await stream_chat(


### PR DESCRIPTION
## Summary

Two small fixes to the validation kit, discovered while running it against a JAX-based partner inference server.

1. **`VK_DROP_SEED=1` env var.** Some serving stacks (notably JAX-based ones) reject the `seed` request parameter with `HTTP 400 "does not support per-request seed"`. The kit's high-entropy spec-decoding call always passes `seed`, so every high-entropy request silently 400'd, the probe processed empty results, and emitted a misleading \"no signals\" verdict against any such server. Setting `VK_DROP_SEED=1` strips `seed` from outgoing requests.

2. **`probe_spec_decoding`: low-entropy temperature 0.0 → 0.01.** vLLM/tpu-inference classify `temperature=0.0` as GREEDY and route the whole batch through a separate fast-path kernel (`do_sampling=False` → argmax only, skipping `topk_mask`/`topp_mask`/`jax.random.categorical`). The high-entropy side at `T=2.0` goes through the full sampling kernel. The resulting per-token-compute gap (~0.20 ms/token on the JAX path) is indistinguishable from a true SD-acceptance gap and inflated the entropy ratio. Bumping to `T=0.01` keeps the low-entropy request in the sampling kernel (so kernel cost matches both sides) while keeping output functionally greedy (sample distribution is a delta at the argmax). Verified empirically: same probe against same endpoint dropped the entropy ratio from `1.21x` to `0.95x` after this change, removing the false borderline signal.

## Test plan

- [x] Ran `probe_spec_decoding` against partner JAX endpoint with `VK_DROP_SEED=1` — both low and high requests succeed, distributions captured
- [x] Compared before/after entropy ratio: 1.21x → 0.95x (kernel-confound removed)
- [x] Verified tokens-per-chunk distributions converge between low/high once kernel is controlled
- [x] No behavioral change for non-JAX/non-greedy-fast-path servers (default `VK_DROP_SEED` is unset)