### PR TITLE
fix(validation_kit): exact prompt-token targeting via chat template

### DIFF
--- a/validation_kit/benchmarks/bench_pareto.py
+++ b/validation_kit/benchmarks/bench_pareto.py
@@ -31,11 +31,30 @@ import httpx
 from common import (
     Endpoint,
     random_prompt,
+    random_prompt_in_tokens,
     stream_chat,
     summary_stats,
     warmup,
     write_json,
 )
+
+
+def _select_prompt_fn(input_tokens: int):
+    """Pick the most accurate prompt generator available.
+
+    `random_prompt_in_tokens` produces a prompt that lands on the requested
+    server-side prompt_tokens exactly (uses HF tokenizer + chat template).
+    Falls back to `random_prompt` (content-tokens only, ignores chat-template
+    overhead) if transformers/jinja2 aren't installed.
+    """
+    try:
+        random_prompt_in_tokens(input_tokens, seed=0)
+        return lambda seed: random_prompt_in_tokens(input_tokens, seed=seed), True
+    except Exception as e:
+        print(f"[pareto] WARNING: token-exact prompts unavailable ({type(e).__name__}: {e}). "
+              "Falling back to random_prompt; server prompt_tokens will exceed "
+              "--input-tokens by the chat-template overhead.")
+        return lambda seed: random_prompt(input_tokens, seed=seed), False
 
 
 async def _one_request(
@@ -70,6 +89,10 @@ async def run_at_concurrency(
     """Sustain `concurrency` in-flight requests for `duration_s` seconds."""
     print(f"  [pareto] c={concurrency}: sustaining for {duration_s:.0f}s")
 
+    gen_prompt, exact = _select_prompt_fn(input_tokens)
+    if concurrency == 1:
+        print(f"  [pareto] prompt mode: {'token-exact' if exact else 'word-count (approx)'}")
+
     results: list[dict] = []
     seed_counter = [6000]
     stop_at = time.perf_counter() + duration_s
@@ -79,7 +102,7 @@ async def run_at_concurrency(
         async with httpx.AsyncClient() as client:
             while time.perf_counter() < stop_at:
                 seed_counter[0] += 1
-                prompt = random_prompt(input_tokens, seed=seed_counter[0])
+                prompt = gen_prompt(seed_counter[0])
                 r = await _one_request(client, endpoint, prompt, max_tokens)
                 if r is not None:
                     results.append(r)

--- a/validation_kit/common.py
+++ b/validation_kit/common.py
@@ -237,6 +237,41 @@ def random_prompt(n_tokens_approx: int, seed: int | None = None) -> str:
     return " ".join(rng.choice(_WORDS) for _ in range(n_words))
 
 
+def random_prompt_in_tokens(
+    target_prompt_tokens: int,
+    seed: int | None = None,
+    tolerance: int = 4,
+    max_iter: int = 20,
+) -> str:
+    """Generate a random prompt that produces exactly `target_prompt_tokens`
+    (within `tolerance`) when wrapped as a single user message via the chat
+    template.
+
+    Use this when you need the server's `usage.prompt_tokens` to land on a
+    specific value -- e.g., to control where `prompt_tokens + max_tokens` sits
+    relative to a server's `max_model_len`. `random_prompt()` is content-token
+    accurate but does not account for chat-template overhead (~600+ tokens for
+    gpt-oss harmony), so the server-reported prompt_tokens is systematically
+    larger than the requested value.
+
+    Requires `transformers` installed and `PARTNER_TOKENIZER` (or default
+    `openai/gpt-oss-120b`) loadable. Assumes the server uses the same chat
+    template as the HF tokenizer.
+    """
+    tok = get_tokenizer()
+    n_words = max(1, target_prompt_tokens)
+    text = ""
+    for _ in range(max_iter):
+        rng = random.Random(seed)
+        text = " ".join(rng.choice(_WORDS) for _ in range(n_words))
+        actual = tok.chat_token_count(text)
+        diff = target_prompt_tokens - actual
+        if abs(diff) <= tolerance:
+            return text
+        n_words = max(1, n_words + diff)
+    return text
+
+
 def repeat_phrase_prompt(target_output_tokens: int = 256) -> str:
     """
     Low-entropy prompt: asks the model to repeat a phrase many times.
@@ -297,6 +332,24 @@ class _LazyTokenizer:
     def count(self, text: str) -> int:
         tok = self._load()
         return len(tok.encode(text, add_special_tokens=False))
+
+    def chat_token_count(self, prompt: str, role: str = "user") -> int:
+        """Token count after wrapping in a single-message chat template.
+
+        Matches what a server reports as `usage.prompt_tokens` (assuming the
+        server uses the same chat template as the HF tokenizer).
+
+        Note: we render with `tokenize=False` and then encode separately,
+        because some chat templates (notably gpt-oss harmony) return only the
+        2-token generation prompt when called with `tokenize=True`.
+        """
+        tok = self._load()
+        rendered = tok.apply_chat_template(
+            [{"role": role, "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        return len(tok.encode(rendered, add_special_tokens=False))
 
 
 _tokenizer_singleton: _LazyTokenizer | None = None


### PR DESCRIPTION
## Summary

`random_prompt(N)` generates a string with roughly N *content* tokens but ignores chat-template overhead, which is large for gpt-oss (the harmony template adds 600+ tokens of system prompt before any user content). Result: the server sees `prompt_tokens = N + ~660`, not N.

Practical impact, especially on servers with small `max_model_len`:

> Before this PR, running `bench_pareto --input-tokens 8000 --output-tokens 1024` against a server with `max_model_len=9216` would silently send 8663-token prompts, leaving only 553 output tokens before the context cap binds. The kit was secretly testing 8.6K/0.5K instead of 8K/1K, and aggregate-throughput numbers were systematically understated.

## Changes

1. **`common.py`: `random_prompt_in_tokens(target_prompt_tokens, seed)`** — iteratively adjusts word count and uses the HF tokenizer's chat template to land server-reported `prompt_tokens` within ±4 of the target.
2. **`common.py`: `_LazyTokenizer.chat_token_count(prompt)`** — helper that renders via `apply_chat_template(tokenize=False, add_generation_prompt=True)` then encodes the string. (Calling `apply_chat_template(tokenize=True)` directly returns only the 2 generation-prompt tokens for gpt-oss harmony, not the full conversation — a footgun this avoids.)
3. **`bench_pareto.py`** — switched the prompt generator to `random_prompt_in_tokens`. Falls back to `random_prompt` with a one-line warning if `transformers`/`jinja2` aren't installed, so the kit still runs without those deps.

## Verification

Tested against a gpt-oss-120b server. Local prediction matches server-reported `prompt_tokens` to within tolerance:

| target | server prompt_tokens | diff |
|---|---|---|
| 1024 | 1023 | -1 |
| 2048 | 2045 | -3 |
| 4096 | 4095 | -1 |
| 6000 | 5998 | -2 |
| 8000 | 8000 | **0** |
| 8192 | 8192 | **0** |
| 9000 | 9000 | **0** |

And the real 8K/1K case now fits cleanly under a 9216 ctx cap:
```
prompt_tokens=8000   completion_tokens=1024   total_tokens=9024
```

## Test plan

- [x] Unit-style verification across 7 target sizes (1K–9K) against live gpt-oss-120b endpoint — within ±4 of target for all
- [x] Verified bench_pareto picks up the new helper and warns gracefully if `transformers` missing
- [x] Verified real 8K/1K shape now achievable on a server with max_model_len=9216 (previously got truncated to ~553 output)