### PR TITLE
Enable OsLogin for TPU and clean up tmp logs when finished

### DIFF
--- a/scripts/agent/docker_run_bm.sh
+++ b/scripts/agent/docker_run_bm.sh
@@ -15,6 +15,10 @@ remove_docker_container() {
     docker rm -f tpu-test || true;
     docker rm -f vllm-tpu || true;
     docker rm -f $CONTAINER_NAME || true;
+    if [ -n "${LOG_ROOT:-}" ] && [ -d "$LOG_ROOT" ] && [ "$LOG_ROOT" != "/" ] && [ "$LOG_ROOT" != "/tmp" ]; then
+        echo "Cleaning up temporary log directory $LOG_ROOT..."
+        rm -rf "$LOG_ROOT" || true
+    fi
 }
 
 trap remove_docker_container EXIT

--- a/scripts/agent/local_run_bm.sh
+++ b/scripts/agent/local_run_bm.sh
@@ -53,6 +53,10 @@ clean_up() {
    pkill -f vllm || true
    pkill -f VLLM || true
    ./scripts/agent/clean_old_vllm_envs.sh || true
+   if [ -n "${LOG_ROOT:-}" ] && [ -d "$LOG_ROOT" ] && [ "$LOG_ROOT" != "/" ] && [ "$LOG_ROOT" != "/tmp" ]; then
+      echo "Cleaning up temporary log directory $LOG_ROOT..."
+      rm -rf "$LOG_ROOT" || true
+   fi
 }
 trap clean_up EXIT
 

--- a/scripts/agent/local_run_bm_v2.sh
+++ b/scripts/agent/local_run_bm_v2.sh
@@ -61,6 +61,10 @@ clean_up() {
    pkill -f vllm || true
    pkill -f VLLM || true
    ./scripts/agent/clean_old_vllm_envs_v2.sh || true
+   if [ -n "${LOG_ROOT:-}" ] && [ -d "$LOG_ROOT" ] && [ "$LOG_ROOT" != "/" ] && [ "$LOG_ROOT" != "/tmp" ]; then
+      echo "Cleaning up temporary log directory $LOG_ROOT..."
+      rm -rf "$LOG_ROOT" || true
+   fi
 }
 trap clean_up EXIT
 

--- a/terraform/gcp/modules/v6e/main.tf
+++ b/terraform/gcp/modules/v6e/main.tf
@@ -37,6 +37,7 @@ resource "google_tpu_v2_vm" "tpu_v6" {
   }
 
   metadata = {
+    "enable-oslogin" = "TRUE"
     "startup-script" = templatefile(var.startup_script_path, {
       purpose          = var.purpose
       project_id       = var.project_id

--- a/terraform/gcp/modules/v7x/main.tf
+++ b/terraform/gcp/modules/v7x/main.tf
@@ -37,6 +37,7 @@ resource "google_tpu_v2_vm" "tpu_v7" {
   }
 
   metadata = {
+    "enable-oslogin" = "TRUE"
     "startup-script" = templatefile(var.startup_script_path, {
       purpose          = var.purpose
       project_id       = var.project_id

--- a/terraform/gcp/modules/v7x_tune/main.tf
+++ b/terraform/gcp/modules/v7x_tune/main.tf
@@ -24,6 +24,7 @@ resource "google_tpu_v2_vm" "tpu_v7" {
   } 
 
   metadata = {
+    "enable-oslogin" = "TRUE"
     "startup-script" = templatefile(var.startup_script_path, {
       purpose          = var.purpose
       project_id       = var.project_id


### PR DESCRIPTION
Our cicd are under google org policy which disable ssh even through iap. Instead ssh should be done through some internal version of ssh helper which require osLogin enabled.

The main purpose of this pr, however, is to address an issue where the boot disk usages growing unbounded due to not cleaning up the tmp files. 