### PR TITLE
Allow customizing env var per model level

### DIFF
--- a/cases/hourly_torchax_jax_v7.csv
+++ b/cases/hourly_torchax_jax_v7.csv
@@ -1,4 +1,4 @@
-Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
-tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024
+Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts,ModelTag,PrefixLen,ExtraEnvs
+tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,,,
+tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,,,TPU_KV_CACHE_HEADROOM_MIB='2048'
+tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024,,,,,

--- a/cases/hourly_tt_v7.csv
+++ b/cases/hourly_tt_v7.csv
@@ -1,4 +1,4 @@
-Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen
-tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024
-tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024
+Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts,ModelTag,PrefixLen,ExtraEnvs
+tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,,,
+tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,,,TPU_KV_CACHE_HEADROOM_MIB='2048'
+tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024,,,,,

--- a/scripts/scheduler/schedule_run.sh
+++ b/scripts/scheduler/schedule_run.sh
@@ -59,7 +59,21 @@ tail -n +2 "$CSV_FILE" | while read -r line || [ -n "${line}" ]; do
     EXPECTED_ETEL \
     NUM_PROMPTS \
     MODELTAG \
-    PREFIX_LEN <<< "$line"
+    PREFIX_LEN \
+    EXTRA_ENVS_CSV <<< "$line"
+
+  # Combine global EXTRA_ENVS with row-specific EXTRA_ENVS_CSV
+  COMBINED_EXTRA_ENVS=""
+  if [ -n "${EXTRA_ENVS:-}" ] && [ -n "${EXTRA_ENVS_CSV:-}" ]; then
+    COMBINED_EXTRA_ENVS="${EXTRA_ENVS};${EXTRA_ENVS_CSV}"
+  elif [ -n "${EXTRA_ENVS:-}" ]; then
+    COMBINED_EXTRA_ENVS="${EXTRA_ENVS}"
+  elif [ -n "${EXTRA_ENVS_CSV:-}" ]; then
+    COMBINED_EXTRA_ENVS="${EXTRA_ENVS_CSV}"
+  fi
+
+  # Escape single quotes for Spanner SQL safety to prevent syntax errors or injection
+  ESCAPED_EXTRA_ENVS="${COMBINED_EXTRA_ENVS//\'/\'\'}"
 
   RECORD_ID=$(uuidgen | tr 'A-Z' 'a-z')
 
@@ -106,7 +120,7 @@ tail -n +2 "$CSV_FILE" | while read -r line || [ -n "${line}" ]; do
       ${NUM_PROMPTS:-1000},
       '${MODELTAG:-PROD}',
       ${PREFIX_LEN:-0},
-      '$EXTRA_ENVS'
+      '$ESCAPED_EXTRA_ENVS'
     );"
   
   # If insert failed, just continue without publishing


### PR DESCRIPTION
This is useful to set TPU_KV_CACHE_HEADROOM_MIB for smaller model run where a large remaining
vram is allocated to kv cache and leaving us not enough headroom to store the kv cache metadata
(essensially the smaller the mode, the larger the kv cache because vllm allocate the remaining
vram to kv cache, and thus larger the kv cache metadata)