### PR TITLE
Use Batched RPA for Qwen

### DIFF
--- a/cases/hourly_torchax_jax_v7.csv
+++ b/cases/hourly_torchax_jax_v7.csv
@@ -1,4 +1,5 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts,ModelTag,PrefixLen,ExtraEnvs
 tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,,,
-tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,,,TPU_KV_CACHE_HEADROOM_MIB=4096
+tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,PROD_BRPA,,VLLM_ATTENTION_BACKEND=CUSTOM
+tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,PROD_BRPA,,VLLM_ATTENTION_BACKEND=CUSTOM
 tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024,,,,,

--- a/cases/hourly_tt_v7.csv
+++ b/cases/hourly_tt_v7.csv
@@ -1,4 +1,5 @@
 Device,Model,MaxNumSeqs,MaxNumBatchedTokens,TensorParallelSize,MaxModelLen,Dataset,InputLen,OutputLen,ExpectedETEL,NumPrompts,ModelTag,PrefixLen,ExtraEnvs
 tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,,,
-tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,,,TPU_KV_CACHE_HEADROOM_MIB=4096
+tpu7x-2,Qwen/Qwen3-Coder-30B-A3B-Instruct,128,10275,1,10275,sonnet,1024,1024,,,PROD_BRPA,,VLLM_ATTENTION_BACKEND=CUSTOM
+tpu7x-2,Qwen/Qwen3-0.6B,128,10275,1,10275,sonnet,1024,1024,,,PROD_BRPA,,VLLM_ATTENTION_BACKEND=CUSTOM
 tpu7x-2,openai/gpt-oss-20b,128,10275,1,10275,sonnet,1024,1024,,,,,

--- a/scripts/agent/run_bm.sh
+++ b/scripts/agent/run_bm.sh
@@ -101,6 +101,10 @@ if [[ "${FORCE_EAGER:-,,}" == "true" ]]; then
   EXTRA_ARGS+=" --enforce-eager"
 fi
 
+if [[ -n "${VLLM_ATTENTION_BACKEND:-}" ]]; then
+  EXTRA_ARGS+=" --attention-backend ${VLLM_ATTENTION_BACKEND}"
+fi
+
 VLLM_USE_V1=1 VLLM_TORCH_PROFILER_DIR="$PROFILE_FOLDER" vllm serve $MODEL \
   --seed 42 \
   --max-num-seqs $MAX_NUM_SEQS \


### PR DESCRIPTION
The `CUSTOM` attention backend refers to a new Batched RPA backend. With this, it will dynamically calculate the title size for qkc to avoid vmem oomed.
The default attention backend does not allow qkv tile size customization and it's simple heuristics cause model with small Q-to-KV head ratio to oom.
TT team confirms that they've been using the batched rpa for Qwen benchmarking, so this pr
1. update the Qwen 0.6B to use it directly to immediately fix the vmem oomed issue
2. add a new entry for Qwen 30B one to compare their perf difference