### PR TITLE
Pause benchmark job generation

### DIFF
--- a/scripts/scheduler/hourly_run.sh
+++ b/scripts/scheduler/hourly_run.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+
+# Benchmark generation is paused. The v6e fleet that consumes these queues is
+# being migrated off the us-east5-a reservation, so publishing more work would
+# only fill Pub/Sub with records no agent will claim -- messages expire after
+# the subscriptions' 7 day retention and leave their Spanner rows stranded in
+# CREATED forever.
+#
+# The guard lives here rather than in hourly_run_wrapper.sh so the wrapper still
+# runs its `git pull`: that pull is the only thing that carries a change from
+# this repo onto the scheduler VM, and gating before it would strand the VM on
+# this commit with no way back short of touching the box.
+#
+# To resume, either flip the default below back to 1 and let the hourly pull
+# pick it up, or export BM_SCHEDULER_ENABLED=1 in /etc/environment on the
+# scheduler VM -- both units read it via EnvironmentFile.
+if [[ "${BM_SCHEDULER_ENABLED:-0}" != "1" ]]; then
+  echo "bm scheduler is paused (BM_SCHEDULER_ENABLED != 1). No jobs created."
+  exit 0
+fi
+
 TIMEZONE="America/Los_Angeles"
 TAG="$(TZ="$TIMEZONE" date +%Y%m%d_%H%M%S)"
 HOUR_NOW=$(TZ="$TIMEZONE" date +%H)

--- a/scripts/scheduler/retry.sh
+++ b/scripts/scheduler/retry.sh
@@ -2,6 +2,21 @@
 
 set -euo pipefail
 
+# Paused alongside hourly_run.sh -- see the note there. This republishes FAILED
+# and stuck RUNNING records, so leaving it live would keep feeding the queues
+# after job creation stops.
+#
+# Note this guard is inert on the current scheduler VM: bm-monitor.service
+# execs this script directly, with no `git pull` ahead of it, so its checkout
+# stays pinned wherever it was deployed. It drains on its own regardless --
+# every query here is bounded to LastUpdate within the last 3 days and
+# TryCount < 2, so once hourly_run.sh stops creating records the retry loop has
+# nothing left to act on within ~3 days.
+if [[ "${BM_SCHEDULER_ENABLED:-0}" != "1" ]]; then
+  echo "bm scheduler is paused (BM_SCHEDULER_ENABLED != 1). Nothing republished."
+  exit 0
+fi
+
 # === Usage ===
 # ./script.sh [RUN_TYPES] [TRY_COUNT]
 # RUN_TYPES: comma-separated (default: HOURLY,AUTOTUNE)


### PR DESCRIPTION
## Why

The v6e fleet that consumes these queues is being migrated off the `us-east5-a` reservation (`cloudtpu-20260710021500-1220042802`). Publishing more work only fills Pub/Sub with records no agent will claim — unclaimed messages expire after the subscriptions' 7 day retention and leave their Spanner rows stranded in `CREATED` forever. That's the source of the ~19k row backlog dating back to Oct 2025.

For context, over the last 14 days the v6e queues looked like this:

| Device | Scheduled | COMPLETED | FAILED | Never picked up |
|---|---|---|---|---|
| v6e-8 | 6,776 | 1,323 | 1,050 | 3,895 |
| v6e-1 | 6,384 | 2,114 | 4,259 | 0 |
| v6e-4 | 1,344 | 191 | 1,149 | 0 |

## What

Both producers are gated on `BM_SCHEDULER_ENABLED`, defaulting to off:

- `hourly_run.sh` — creates the hourly and daily cases
- `retry.sh` — republishes `FAILED` and stuck `RUNNING` records

## Placement

The guard sits in `hourly_run.sh` rather than `hourly_run_wrapper.sh` deliberately. The wrapper's `git pull` is the only channel that carries a change from this repo onto the scheduler VM, so gating ahead of it would pin the box on this commit with no way back short of logging in. Left where it is, the pull still runs hourly and resuming is one more commit.

## Scope

The `retry.sh` guard is inert on the scheduler VM as deployed today: `bm-monitor.service` execs the script directly with no `git pull`, and its checkout is pinned well behind `main`. It drains on its own regardless — every query there is bounded to `LastUpdate` within 3 days and `TryCount < 2`, so it runs out of eligible records within ~3 days of creation stopping.

Not affected by this PR: messages already in Pub/Sub (agents keep draining them), and the TPU VMs themselves, which just go idle. Removing those is a separate Terraform change.

## Resuming

Either flip the default back to `1`, or export `BM_SCHEDULER_ENABLED=1` in `/etc/environment` on the scheduler VM — both units read it via `EnvironmentFile`.

## Test

- `bash -n` clean on both scripts
- Unset → both exit 0 without publishing
- `BM_SCHEDULER_ENABLED=1` → proceeds past the guard normally