### PR TITLE
Give one v6e-8 back to the tpu-inference CI fleet

### DIFF
--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -6,9 +6,15 @@
 |--------------------------------|----------------------------|--------------------|----------------------|-----------------|-------|-------|-------|---------|---------|---------|---------|
 | infer_test_southamerica_west1  | cloud-tpu-inference-test   | southamerica-west1 | southamerica-west1-a | 200             |4      | 0     | 12    |   0     |   0     |   0     |   0     |
 | cloud-tpu-inference-test       | cloud-tpu-inference-test   | southamerica-west1 | us-east5-a           | 400             |0      | 0     | 0     |   0     |   0     |   0     |   0     |
-| ci_cd                          | cloud-ullm-inference-ci-cd | us-central1        | us-east5-a           | 600             |10     | 2     | 2     |   0     |   0     |   0     |   0     |
+| ci_cd                          | cloud-ullm-inference-ci-cd | us-central1        | us-east5-a           | 600             |10     | 2     | 1     |   0     |   0     |   0     |   0     |
 
 `ci_cd` covers every zone in `cloud-ullm-inference-ci-cd`, not one folder per
 region. v6e goes in `tpu_zone`, tpu7x in `tpu7x_zone` (us-central1-c), since
 `modules/v6e` and `modules/v7x` both take the zone as a variable rather than
 reading it from the provider.
+
+`ci_cd`'s v6e counts are capped by a **128 ct6e reservation in us-east5-a shared
+with the tpu-inference CI fleet**, at zero headroom. Benchmarks hold 26 of the
+128 (10 × v6e-1, 2 × v6e-4, 1 × v6e-8); CI holds the other 102. Growing any
+count here means CI has to give the chips back first, and vice versa — the two
+sides move in paired PRs, lower-count-first.

--- a/terraform/gcp/ci_cd/variables.tf
+++ b/terraform/gcp/ci_cd/variables.tf
@@ -39,7 +39,7 @@ variable "v6e_4_count" {
 }
 
 variable "v6e_8_count" {
-  default     = 2
+  default     = 1
 }
 
 variable "v7x_2_tt_count" {


### PR DESCRIPTION
`ci_cd`'s `v6e_8_count` 2 → 1.

## Why

The us-east5-a reservation the benchmark fleet now shares with tpu-inference CI is **128 ct6e at zero headroom** — CI 94, benchmarks 34. CI's v6e-8 fleet has been one node short (8, was 9) since the reservation move, and the missing node costs 8 chips the reservation does not have. So it is a trade, not a request.

After this: benchmarks 26 (10 × v6e-1, 2 × v6e-4, 1 × v6e-8), CI 102. Still 128/128.

## Why v6e-8 and not the two v6e-4

Dropping both v6e-4 would also free exactly 8 chips, but those two are the **only v6e-4 in the entire benchmark fleet** — `infer_test_southamerica_west1` declares 0 and `cloud-tpu-inference-test` is all zeros. 7 hourly cases need them, including a customer autotune sweep.

v6e-8 goes 14 → 13 fleet-wide instead, and 12 of the 13 are still in `southamerica-west1-a`. 49 hourly cases use v6e-8, so the marginal loss is one node out of a much deeper pool.

## Ordering

**Apply this PR first.** The reservation has no room for CI's index 6 until this node is destroyed. Pairs with ci-infra#494, which takes `ci_v6e_8` 6 → 7.

## Also

`terraform/gcp/README.md` gains a paragraph recording the shared-reservation constraint, so the next person to bump a count in `ci_cd` knows the chips have to come from CI first.